### PR TITLE
Set max supply to 0

### DIFF
--- a/src/deploy/process.rs
+++ b/src/deploy/process.rs
@@ -275,7 +275,7 @@ fn create_candy_machine_data(config: &ConfigData, uuid: String) -> Result<CandyM
         price: price_as_lamports(config.price),
         symbol: config.symbol.clone(),
         seller_fee_basis_points: config.seller_fee_basis_points,
-        max_supply: config.number,
+        max_supply: 0,
         is_mutable: config.is_mutable,
         retain_authority: config.retain_authority,
         go_live_date,


### PR DESCRIPTION
Max supply is currently being set to the number of items in the candy machine - this allows the creation of editions of the NFT. The value must be set to `0`.