### PR TITLE
chore: change bundlr dependency to crates.io package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,7 +1052,8 @@ checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 [[package]]
 name = "bundlr-sdk"
 version = "0.1.0"
-source = "git+https://github.com/Bundlr-Network/rust-sdk#f839ad2b6ef4d1d79e0dfc6d9cbfc9e40adf0714"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87d20a1408c0238b23ae725df71e8365bd62b70933f2ee91451bf701380554a"
 dependencies = [
  "actix-files",
  "anyhow",
@@ -1079,6 +1080,7 @@ dependencies = [
  "serde 1.0.136",
  "serde_json 1.0.78",
  "sha2 0.10.1",
+ "thiserror",
  "tokio",
  "tokio-util",
 ]
@@ -4810,7 +4812,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "sugar-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anchor-client",
  "anchor-lang",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,7 @@ async-trait = "0.1.52"
 aws-config = "0.9.0"
 aws-sdk-s3 = "0.9.0"
 bs58 = "0.4.0"
-bundlr-sdk = { git = "https://github.com/Bundlr-Network/rust-sdk", features = [
-  "solana",
-] }
+bundlr-sdk = {version = "0.1.0", features = [ "solana"] }
 chrono = "0.4.19"
 clap = { version = "3.0.0", features = ["derive", "cargo"] }
 console = "0.15.0"


### PR DESCRIPTION
This should fix the build fails on `main`. 