### PR TITLE
Added candy machine id parameter

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -76,6 +76,9 @@ pub enum Commands {
         /// Amount of NFTs to be minted in bulk
         #[clap(short, long)]
         number: Option<u64>,
+
+        /// Address of candy machine to mint from.
+        candy_machine: Option<String>,
     },
 
     /// Update the candy machine config on-chain
@@ -99,6 +102,9 @@ pub enum Commands {
         /// Pubkey for the new authority
         #[clap(short, long)]
         new_authority: Option<String>,
+
+        /// Address of candy machine to update.
+        candy_machine: Option<String>,
     },
 
     /// Deploy cache items into candy machine config on-chain

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,11 +127,13 @@ async fn run() -> Result<()> {
             rpc_url,
             cache,
             number,
+            candy_machine,
         } => process_mint(MintArgs {
             keypair,
             rpc_url,
             cache,
             number,
+            candy_machine,
         })?,
         Commands::Update {
             config,
@@ -139,12 +141,14 @@ async fn run() -> Result<()> {
             rpc_url,
             cache,
             new_authority,
+            candy_machine,
         } => process_update(UpdateArgs {
             config,
             keypair,
             rpc_url,
             cache,
             new_authority,
+            candy_machine,
         })?,
         Commands::Deploy {
             config,


### PR DESCRIPTION
Both `mint` and `update` commands now accept a candy machine parameter, allowing using these commands without a cache file.