### PR TITLE
Propagating setup errors

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -5,7 +5,7 @@ use anchor_client::{
     },
     Client, Cluster,
 };
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use tracing::error;
 
 use crate::config::data::SugarConfig;
@@ -43,8 +43,7 @@ pub fn sugar_setup(
             Ok(keypair) => keypair,
             Err(e) => {
                 error!("Failed to read keypair file: {}", e);
-                println!("Failed to read keypair file: {}", e);
-                std::process::exit(1);
+                return Err(anyhow!("Failed to read keypair file: {}", e));
             }
         },
 
@@ -56,19 +55,22 @@ pub fn sugar_setup(
                         "Failed to read keypair file: {}, {}",
                         &sol_config.keypair_path, e
                     );
-                    println!(
+                    return Err(anyhow!(
                         "Failed to read keypair file: {}, {}",
-                        &sol_config.keypair_path, e
-                    );
-                    std::process::exit(1);
+                        &sol_config.keypair_path,
+                        e
+                    ));
                 }
             },
             None => match read_keypair_file(&*shellexpand::tilde(DEFAULT_KEYPATH)) {
                 Ok(keypair) => keypair,
                 Err(e) => {
                     error!("Failed to read keypair file: {}, {}", DEFAULT_KEYPATH, e);
-                    println!("Failed to read keypair file: {}, {}", DEFAULT_KEYPATH, e);
-                    std::process::exit(1);
+                    return Err(anyhow!(
+                        "Failed to read keypair file: {}, {}",
+                        DEFAULT_KEYPATH,
+                        e
+                    ));
                 }
             },
         },


### PR DESCRIPTION
Propagates the errors from `sugar_setup` instead of printing them, so error reporting is consistent.

- Before:
![Screenshot from 2022-04-30 12-37-05](https://user-images.githubusercontent.com/729235/166104007-3a412d1f-4eca-4541-a64c-14a46be9dac6.png)

- With this PR:
![Screenshot from 2022-04-30 12-38-28](https://user-images.githubusercontent.com/729235/166104015-d451293d-f159-49b9-8a2a-e0bee9a9f0e3.png)


