### PR TITLE
Added flag to specify candy machine id

### DIFF
--- a/script/sugar-cli-test.sh
+++ b/script/sugar-cli-test.sh
@@ -693,7 +693,7 @@ if [ "${CLOSE}" = "Y" ]; then
     CYN "7. Withdrawing Candy Machine funds and clean up"
     echo ""
     MAG ">>>"
-    $SUGAR_BIN withdraw --keypair $WALLET_KEY -r $RPC $CANDY_MACHINE_ID
+    $SUGAR_BIN withdraw --keypair $WALLET_KEY -r $RPC --candy-machine $CANDY_MACHINE_ID
     EXIT_CODE=$?
     MAG "<<<"
     

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -78,6 +78,7 @@ pub enum Commands {
         number: Option<u64>,
 
         /// Address of candy machine to mint from.
+        #[clap(long)]
         candy_machine: Option<String>,
     },
 
@@ -104,6 +105,7 @@ pub enum Commands {
         new_authority: Option<String>,
 
         /// Address of candy machine to update.
+        #[clap(long)]
         candy_machine: Option<String>,
     },
 
@@ -152,6 +154,7 @@ pub enum Commands {
     /// Withdraw funds from candy machine account closing it
     Withdraw {
         /// Address of candy machine to withdraw funds from.
+        #[clap(long)]
         candy_machine: Option<String>,
 
         /// Path to the keypair file, uses Sol config or defaults to "~/.config/solana/id.json"


### PR DESCRIPTION
The candy machine id can be specified as an optional `--candy-machine` flag