### PR TITLE
Exit on second interruption

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -107,10 +107,9 @@ async fn run() -> Result<()> {
         if !r.load(Ordering::SeqCst) {
             // we really need to exit
             println!(
-                "\n\n{}{} {}",
+                "\n\n{}{} Operation aborted.",
                 ERROR_EMOJI,
                 style("Error running command (re-run needed):").red(),
-                "Operation aborted.",
             );
             // finished the program with an error code to the OS
             std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,18 @@ async fn run() -> Result<()> {
     let r = running.clone();
 
     ctrlc::set_handler(move || {
+        if !r.load(Ordering::SeqCst) {
+            // we really need to exit
+            println!(
+                "\n\n{}{} {}",
+                ERROR_EMOJI,
+                style("Error running command (re-run needed):").red(),
+                "Operation aborted.",
+            );
+            // finished the program with an error code to the OS
+            std::process::exit(1);
+        }
+
         r.store(false, Ordering::SeqCst);
     })
     .expect("Error setting Ctrl-C handler");


### PR DESCRIPTION
Interrupts any command after a second `Ctrl+C`