### PR TITLE
refactor(interruption): handling interruptions in non-iterative operations

### DIFF
--- a/src/deploy/data.rs
+++ b/src/deploy/data.rs
@@ -5,5 +5,5 @@ pub struct DeployArgs {
     pub cache: String,
     pub keypair: Option<String>,
     pub rpc_url: Option<String>,
-    pub handler: Arc<AtomicBool>,
+    pub interrupted: Arc<AtomicBool>,
 }

--- a/src/launch/process.rs
+++ b/src/launch/process.rs
@@ -19,7 +19,7 @@ pub struct LaunchArgs {
     pub rpc_url: Option<String>,
     pub cache: String,
     pub strict: bool,
-    pub handler: Arc<AtomicBool>,
+    pub interrupted: Arc<AtomicBool>,
 }
 
 pub async fn process_launch(args: LaunchArgs) -> Result<()> {
@@ -69,7 +69,7 @@ pub async fn process_launch(args: LaunchArgs) -> Result<()> {
         keypair: args.keypair.clone(),
         rpc_url: args.rpc_url.clone(),
         cache: args.cache.clone(),
-        handler: args.handler.clone(),
+        interrupted: args.interrupted.clone(),
     };
 
     process_upload(upload_args).await?;
@@ -81,7 +81,7 @@ pub async fn process_launch(args: LaunchArgs) -> Result<()> {
         keypair: args.keypair.clone(),
         rpc_url: args.rpc_url.clone(),
         cache: args.cache.clone(),
-        handler: args.handler.clone(),
+        interrupted: args.interrupted.clone(),
     };
 
     process_deploy(deploy_args).await?;

--- a/src/upload/aws.rs
+++ b/src/upload/aws.rs
@@ -94,7 +94,7 @@ impl UploadHandler for AWSHandler {
         cache: &mut Cache,
         indices: &[usize],
         data_type: DataType,
-        handler: Arc<AtomicBool>,
+        interrupted: Arc<AtomicBool>,
     ) -> Result<Vec<UploadError>> {
         let mut extension = HashSet::with_capacity(1);
         let mut paths = Vec::new();
@@ -176,7 +176,7 @@ impl UploadHandler for AWSHandler {
 
         let mut errors = Vec::new();
 
-        while handler.load(Ordering::SeqCst) && !handles.is_empty() {
+        while !interrupted.load(Ordering::SeqCst) && !handles.is_empty() {
             match select_all(handles).await {
                 (Ok(res), _index, remaining) => {
                     // independently if the upload was successful or not

--- a/src/upload/bundlr.rs
+++ b/src/upload/bundlr.rs
@@ -327,7 +327,7 @@ impl UploadHandler for BundlrHandler {
         cache: &mut Cache,
         indices: &[usize],
         data_type: DataType,
-        handler: Arc<AtomicBool>,
+        interrupted: Arc<AtomicBool>,
     ) -> Result<Vec<UploadError>> {
         let mut extension = HashSet::with_capacity(1);
         let mut paths = Vec::new();
@@ -410,7 +410,7 @@ impl UploadHandler for BundlrHandler {
 
         let mut errors = Vec::new();
 
-        while handler.load(Ordering::SeqCst) && !handles.is_empty() {
+        while !interrupted.load(Ordering::SeqCst) && !handles.is_empty() {
             match select_all(handles).await {
                 (Ok(res), _index, remaining) => {
                     // independently if the upload was successful or not


### PR DESCRIPTION
Couple of improvements to how `Ctrl+C` interruptions are handled:
- on non-iterative operations, a single `Ctrl+C` will exit the program immediately
- on iterative operations (`upload` and `deploy`), the first `Ctrl+C` signal that the user wants to abort the operation and the command has time to save any data; a second `Ctrl+C` exits the program immediately

The interruption variable was renamed to better reflect its use.