### PR TITLE
fix(create-config): fix empty assets folder test

### DIFF
--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -176,7 +176,7 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
 
     // number
 
-    config_data.number = if (num_files % 2) == 0 && Confirm::with_theme(&theme)
+    config_data.number = if num_files > 0 && (num_files % 2) == 0 && Confirm::with_theme(&theme)
         .with_prompt(
             format!(
                 "Found {} file pairs in \"{}\". Is this how many NFTs you will have in your candy machine?", num_files / 2, args.assets_dir,


### PR DESCRIPTION
Avoids asking if the number of assets is correct when the `assets` folder is empty:

- Behaviour avoided:
![image](https://user-images.githubusercontent.com/729235/167146866-37907ea1-2332-496b-a057-2b9dc3fe2f51.png)
