### PR TITLE
refactor(create-config, upload): improve serde metadata errors

### DIFF
--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -159,7 +159,7 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
 
         let m = File::open(&metadata_file)?;
         let metadata: Metadata = serde_json::from_reader(m).map_err(|e| {
-            anyhow!("Failed to read metadata file: {metadata_file} with error: {e}")
+            anyhow!("Failed to read metadata file: '{metadata_file}' with error: {e}")
         })?;
 
         symbol = metadata.symbol;

--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -159,7 +159,7 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
 
         let m = File::open(&metadata_file)?;
         let metadata: Metadata = serde_json::from_reader(m).map_err(|e| {
-            anyhow!("Failed to read metadata file: '{metadata_file}' with error: {e}")
+            anyhow!("Failed to read metadata file '{metadata_file}' with error: {e}")
         })?;
 
         symbol = metadata.symbol;

--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -1,5 +1,5 @@
 use anchor_lang::prelude::Pubkey;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use chrono::DateTime;
 use console::{style, Style};
 use dialoguer::Confirm;
@@ -158,7 +158,9 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
             .to_string();
 
         let m = File::open(&metadata_file)?;
-        let metadata: Metadata = serde_json::from_reader(m)?;
+        let metadata: Metadata = serde_json::from_reader(m).map_err(|e| {
+            anyhow!("Failed to read metadata file: {metadata_file} with error: {e}")
+        })?;
 
         symbol = metadata.symbol;
         seller_fee = metadata.seller_fee_basis_points;

--- a/src/upload/assets.rs
+++ b/src/upload/assets.rs
@@ -135,7 +135,7 @@ pub fn get_asset_pairs(assets_dir: &str) -> Result<HashMap<usize, AssetPair>> {
 
         let m = File::open(&metadata_file)?;
         let metadata: Metadata = serde_json::from_reader(m).map_err(|e| {
-            anyhow!("Failed to read metadata file: {metadata_file} with error: {e}")
+            anyhow!("Failed to read metadata file: '{metadata_file}' with error: {e}")
         })?;
         let name = metadata.name.clone();
 
@@ -176,7 +176,7 @@ pub fn get_updated_metadata(metadata_file: &str, media_link: &str) -> Result<Str
             .read(true)
             .open(metadata_file)
             .map_err(|e| {
-                anyhow!("Failed to read metadata file: {metadata_file} with error: {e}")
+                anyhow!("Failed to read metadata file: '{metadata_file}' with error: {e}")
             })?;
         serde_json::from_reader(&m)?
     };

--- a/src/upload/assets.rs
+++ b/src/upload/assets.rs
@@ -134,7 +134,9 @@ pub fn get_asset_pairs(assets_dir: &str) -> Result<HashMap<usize, AssetPair>> {
             .to_string();
 
         let m = File::open(&metadata_file)?;
-        let metadata: Metadata = serde_json::from_reader(m)?;
+        let metadata: Metadata = serde_json::from_reader(m).map_err(|e| {
+            anyhow!("Failed to read metadata file: {metadata_file} with error: {e}")
+        })?;
         let name = metadata.name.clone();
 
         let asset_pair = AssetPair {
@@ -170,7 +172,12 @@ fn encode(file: &str) -> Result<String> {
 
 pub fn get_updated_metadata(metadata_file: &str, media_link: &str) -> Result<String> {
     let mut metadata: Metadata = {
-        let m = OpenOptions::new().read(true).open(metadata_file)?;
+        let m = OpenOptions::new()
+            .read(true)
+            .open(metadata_file)
+            .map_err(|e| {
+                anyhow!("Failed to read metadata file: {metadata_file} with error: {e}")
+            })?;
         serde_json::from_reader(&m)?
     };
 

--- a/src/upload/assets.rs
+++ b/src/upload/assets.rs
@@ -135,7 +135,7 @@ pub fn get_asset_pairs(assets_dir: &str) -> Result<HashMap<usize, AssetPair>> {
 
         let m = File::open(&metadata_file)?;
         let metadata: Metadata = serde_json::from_reader(m).map_err(|e| {
-            anyhow!("Failed to read metadata file: '{metadata_file}' with error: {e}")
+            anyhow!("Failed to read metadata file '{metadata_file}' with error: {e}")
         })?;
         let name = metadata.name.clone();
 
@@ -176,7 +176,7 @@ pub fn get_updated_metadata(metadata_file: &str, media_link: &str) -> Result<Str
             .read(true)
             .open(metadata_file)
             .map_err(|e| {
-                anyhow!("Failed to read metadata file: '{metadata_file}' with error: {e}")
+                anyhow!("Failed to read metadata file '{metadata_file}' with error: {e}")
             })?;
         serde_json::from_reader(&m)?
     };


### PR DESCRIPTION
Improves metadata deserialization errors to include more information. Fixes #201 . 

Errors now look like this:

```
samuel@Samuels-MacBook-Pro sugar_test2 % sugar create-config
[1/2] 🍬 Sugar interactive config maker

Check out our Candy Machine config docs to learn about the options:
  -> https://docs.metaplex.com/candy-machine-v2/configuration


🛑 Error running command (re-run needed): Failed to read metadata file: assets/0.json with error: missing field `name` at line 34 column 1
```
