### PR TITLE
bugfix: Remove placeholder auth delegation

### DIFF
--- a/src/candy_machine.rs
+++ b/src/candy_machine.rs
@@ -26,7 +26,6 @@ pub struct ConfigStatus {
 
 pub fn parse_config_price(client: &Client, config: &ConfigData) -> Result<u64> {
     let parsed_price = if let Some(spl_token) = config.spl_token {
-        println!("SPL TOKEN FOUND");
         let token_program = client.program(token_program_id());
         let token_mint = check_spl_token(&token_program, &spl_token.to_string())?;
 

--- a/src/candy_machine.rs
+++ b/src/candy_machine.rs
@@ -1,13 +1,18 @@
 use anchor_client::solana_sdk::pubkey::Pubkey;
+use anchor_client::Client;
 use anchor_lang::AccountDeserialize;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 
 use mpl_candy_machine::{CandyMachine, CandyMachineData, WhitelistMintMode, WhitelistMintSettings};
 
 use crate::config::data::SugarConfig;
+use crate::config::{price_as_lamports, ConfigData};
 use crate::setup::setup_client;
 
+use crate::utils::check_spl_token;
+
 pub use mpl_candy_machine::ID;
+use spl_token::id as token_program_id;
 // To test a custom candy machine program, comment the line above and use the
 // following lines to declare the id to use:
 //use solana_program::declare_id;
@@ -17,6 +22,23 @@ pub use mpl_candy_machine::ID;
 pub struct ConfigStatus {
     pub index: u32,
     pub on_chain: bool,
+}
+
+pub fn parse_config_price(client: &Client, config: &ConfigData) -> Result<u64> {
+    let parsed_price = if let Some(spl_token) = config.spl_token {
+        println!("SPL TOKEN FOUND");
+        let token_program = client.program(token_program_id());
+        let token_mint = check_spl_token(&token_program, &spl_token.to_string())?;
+
+        match (config.price as u64).checked_mul(10u64.pow(token_mint.decimals.into())) {
+            Some(price) => price,
+            None => return Err(anyhow!("Price math overflow")),
+        }
+    } else {
+        price_as_lamports(config.price)
+    };
+
+    Ok(parsed_price)
 }
 
 pub fn get_candy_machine_state(

--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -350,7 +350,8 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
                     .with_prompt("What is your SPL token mint address?")
                     .validate_with(pubkey_validator)
                     .validate_with(|input: &String| -> Result<()> {
-                        check_spl_token(&program, input)
+                        check_spl_token(&program, input)?;
+                        Ok(())
                     })
                     .interact()
                     .unwrap(),

--- a/src/deploy/process.rs
+++ b/src/deploy/process.rs
@@ -301,7 +301,7 @@ fn create_candy_machine_data(
         ));
     }
 
-    let price = parse_config_price(&client, &config)?;
+    let price = parse_config_price(client, config)?;
 
     let data = CandyMachineData {
         uuid,

--- a/src/deploy/process.rs
+++ b/src/deploy/process.rs
@@ -26,7 +26,6 @@ pub use mpl_token_metadata::state::{
     MAX_CREATOR_LIMIT, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH,
 };
 
-use crate::cache::*;
 use crate::candy_machine::uuid_from_pubkey;
 use crate::candy_machine::ID as CANDY_MACHINE_ID;
 use crate::common::*;
@@ -36,6 +35,7 @@ use crate::deploy::errors::*;
 use crate::setup::{setup_client, sugar_setup};
 use crate::utils::*;
 use crate::validate::parser::{check_name, check_seller_fee_basis_points, check_symbol, check_url};
+use crate::{cache::*, candy_machine::parse_config_price};
 
 /// The maximum config line bytes per transaction.
 const MAX_TRANSACTION_BYTES: usize = 1000;
@@ -120,7 +120,7 @@ pub async fn process_deploy(args: DeployArgs) -> Result<()> {
         let candy_pubkey = candy_keypair.pubkey();
 
         let uuid = uuid_from_pubkey(&candy_pubkey);
-        let candy_data = create_candy_machine_data(&config_data, uuid)?;
+        let candy_data = create_candy_machine_data(&client, &config_data, uuid)?;
         let program = client.program(CANDY_MACHINE_ID);
 
         let treasury_wallet = match config_data.spl_token {
@@ -253,7 +253,11 @@ pub async fn process_deploy(args: DeployArgs) -> Result<()> {
 }
 
 /// Create the candy machine data struct.
-fn create_candy_machine_data(config: &ConfigData, uuid: String) -> Result<CandyMachineData> {
+fn create_candy_machine_data(
+    client: &Client,
+    config: &ConfigData,
+    uuid: String,
+) -> Result<CandyMachineData> {
     let go_live_date = Some(go_live_date_as_timestamp(&config.go_live_date)?);
 
     let end_settings = config.end_settings.as_ref().map(|s| s.into_candy_format());
@@ -297,9 +301,11 @@ fn create_candy_machine_data(config: &ConfigData, uuid: String) -> Result<CandyM
         ));
     }
 
+    let price = parse_config_price(&client, &config)?;
+
     let data = CandyMachineData {
         uuid,
-        price: price_as_lamports(config.price),
+        price,
         symbol: config.symbol.clone(),
         seller_fee_basis_points: config.seller_fee_basis_points,
         max_supply: 0,

--- a/src/mint/process.rs
+++ b/src/mint/process.rs
@@ -159,8 +159,6 @@ pub fn mint(
             false
         };
 
-        println!("Is Mint enabled {mint_enabled}");
-
         if let Some(wl_mint_settings) = &candy_machine_data.whitelist_mint_settings {
             if wl_mint_settings.presale {
                 // we (temporarily) enable the mint - we will validate if the user

--- a/src/mint/process.rs
+++ b/src/mint/process.rs
@@ -240,7 +240,6 @@ pub fn mint(
 
     // Check whitelist mint settings
     if let Some(wl_mint_settings) = &candy_machine_data.whitelist_mint_settings {
-        println!("Whitelist mode encountered");
         let whitelist_token_account = get_ata_for_mint(&wl_mint_settings.mint, &payer);
 
         additional_accounts.push(AccountMeta {

--- a/src/mint/process.rs
+++ b/src/mint/process.rs
@@ -1,6 +1,5 @@
 use anchor_client::{
     solana_sdk::{
-        instruction::Instruction,
         program_pack::Pack,
         pubkey::Pubkey,
         signature::{Keypair, Signature, Signer},
@@ -12,7 +11,6 @@ use anchor_lang::prelude::AccountMeta;
 use anyhow::Result;
 use chrono::Utc;
 use console::style;
-use rand::rngs::OsRng;
 use spl_associated_token_account::{create_associated_token_account, get_associated_token_address};
 use spl_token::{
     instruction::{initialize_mint, mint_to},
@@ -161,6 +159,8 @@ pub fn mint(
             false
         };
 
+        println!("Is Mint enabled {mint_enabled}");
+
         if let Some(wl_mint_settings) = &candy_machine_data.whitelist_mint_settings {
             if wl_mint_settings.presale {
                 // we (temporarily) enable the mint - we will validate if the user
@@ -238,60 +238,39 @@ pub fn mint(
         1,
     )?;
 
-    let mut additional_instructions: Vec<Instruction> = Vec::new();
-    let mut cleanup_instructions: Vec<Instruction> = Vec::new();
     let mut additional_accounts: Vec<AccountMeta> = Vec::new();
-    let mut additional_signers: Vec<Keypair> = Vec::new();
 
     // Check whitelist mint settings
     if let Some(wl_mint_settings) = &candy_machine_data.whitelist_mint_settings {
-        let whitelist_token = get_ata_for_mint(&wl_mint_settings.mint, &payer);
+        println!("Whitelist mode encountered");
+        let whitelist_token_account = get_ata_for_mint(&wl_mint_settings.mint, &payer);
 
         additional_accounts.push(AccountMeta {
-            pubkey: whitelist_token,
+            pubkey: whitelist_token_account,
             is_signer: false,
             is_writable: true,
         });
 
         if wl_mint_settings.mode == WhitelistMintMode::BurnEveryTime {
-            let whitelist_burn_authority = Keypair::generate(&mut OsRng);
-
-            additional_accounts.push(AccountMeta {
-                pubkey: wl_mint_settings.mint,
-                is_signer: false,
-                is_writable: true,
-            });
-            additional_accounts.push(AccountMeta {
-                pubkey: whitelist_burn_authority.pubkey(),
-                is_signer: true,
-                is_writable: false,
-            });
-
             let mut token_found = false;
 
-            match program.rpc().get_account_data(&whitelist_token) {
+            match program.rpc().get_account_data(&whitelist_token_account) {
                 Ok(ata_data) => {
                     if !ata_data.is_empty() {
                         let account = Account::unpack_unchecked(&ata_data)?;
 
                         if account.amount > 0 {
-                            let approve_ix = spl_token::instruction::approve(
-                                &TOKEN_PROGRAM_ID,
-                                &whitelist_token,
-                                &whitelist_burn_authority.pubkey(),
-                                &payer,
-                                &[],
-                                1,
-                            )?;
-                            let revoke_ix = spl_token::instruction::revoke(
-                                &TOKEN_PROGRAM_ID,
-                                &whitelist_token,
-                                &payer,
-                                &[],
-                            )?;
+                            additional_accounts.push(AccountMeta {
+                                pubkey: wl_mint_settings.mint,
+                                is_signer: false,
+                                is_writable: true,
+                            });
 
-                            additional_instructions.push(approve_ix);
-                            cleanup_instructions.push(revoke_ix);
+                            additional_accounts.push(AccountMeta {
+                                pubkey: payer,
+                                is_signer: true,
+                                is_writable: false,
+                            });
 
                             token_found = true;
                         }
@@ -303,51 +282,23 @@ pub fn mint(
             if !token_found {
                 return Err(anyhow!(ErrorCode::NoWhitelistToken));
             }
-
-            additional_signers.push(whitelist_burn_authority);
         }
     }
 
     if let Some(token_mint) = candy_machine_state.token_mint {
-        let transfer_authority = Keypair::generate(&mut OsRng);
-
-        let user_paying_account_address = get_ata_for_mint(&token_mint, &payer);
+        let user_token_account_info = get_ata_for_mint(&token_mint, &payer);
 
         additional_accounts.push(AccountMeta {
-            pubkey: user_paying_account_address,
+            pubkey: user_token_account_info,
             is_signer: false,
             is_writable: true,
         });
 
         additional_accounts.push(AccountMeta {
-            pubkey: transfer_authority.pubkey(),
+            pubkey: payer,
             is_signer: true,
             is_writable: false,
-        });
-
-        let ata_exists = !program.rpc().get_account_data(&token_mint)?.is_empty();
-
-        if ata_exists {
-            let approve_ix = spl_token::instruction::approve(
-                &TOKEN_PROGRAM_ID,
-                &user_paying_account_address,
-                &transfer_authority.pubkey(),
-                &payer,
-                &[],
-                candy_machine_data.price,
-            )?;
-            let revoke_ix = spl_token::instruction::revoke(
-                &TOKEN_PROGRAM_ID,
-                &user_paying_account_address,
-                &payer,
-                &[],
-            )?;
-
-            additional_instructions.push(approve_ix);
-            cleanup_instructions.push(revoke_ix);
-        }
-
-        additional_signers.push(transfer_authority);
+        })
     }
 
     let metadata_pda = get_metadata_pda(&nft_mint.pubkey());
@@ -382,40 +333,15 @@ pub fn mint(
         })
         .args(nft_instruction::MintNft { creator_bump });
 
-    // Add additional instructions based on candy machine settings.
-    if !additional_instructions.is_empty() {
-        for instruction in additional_instructions {
-            builder = builder.instruction(instruction);
-        }
-    }
-
     if !additional_accounts.is_empty() {
         for account in additional_accounts {
             builder = builder.accounts(account);
         }
     }
 
-    if !additional_signers.is_empty() {
-        for signer in &additional_signers {
-            builder = builder.signer(signer);
-        }
-    }
-
     let sig = builder.send()?;
 
-    // Cleanup instructions, such as revoke token burn authority, require a separate transaction.
-    let mut builder = program.request();
-
-    if !cleanup_instructions.is_empty() {
-        for instruction in cleanup_instructions {
-            builder = builder.instruction(instruction);
-        }
-    }
-
-    let sig2 = builder.send()?;
-
     info!("Minted! TxId: {}", sig);
-    info!("Cleanup TxId: {}", sig2);
 
     Ok(sig)
 }

--- a/src/update/process.rs
+++ b/src/update/process.rs
@@ -8,8 +8,8 @@ use std::str::FromStr;
 use mpl_candy_machine::instruction as nft_instruction;
 use mpl_candy_machine::{accounts as nft_accounts, CandyMachineData};
 
-use crate::candy_machine::get_candy_machine_state;
 use crate::candy_machine::ID as CANDY_MACHINE_ID;
+use crate::candy_machine::{get_candy_machine_state, parse_config_price};
 use crate::common::*;
 use crate::config::{data::*, parser::get_config_data};
 use crate::utils::{check_spl_token, check_spl_token_account, spinner_with_style};
@@ -59,7 +59,8 @@ pub fn process_update(args: UpdateArgs) -> Result<()> {
     pb.set_message("Connecting...");
 
     let candy_machine_state = get_candy_machine_state(&sugar_config, &candy_pubkey)?;
-    let candy_machine_data = create_candy_machine_data(&config_data, candy_machine_state.data)?;
+    let candy_machine_data =
+        create_candy_machine_data(&client, &config_data, candy_machine_state.data)?;
 
     pb.finish_with_message("Done");
 
@@ -170,6 +171,7 @@ pub fn process_update(args: UpdateArgs) -> Result<()> {
 }
 
 fn create_candy_machine_data(
+    client: &Client,
     config: &ConfigData,
     candy_machine: CandyMachineData,
 ) -> Result<CandyMachineData> {
@@ -190,9 +192,13 @@ fn create_candy_machine_data(
 
     let gatekeeper = config.gatekeeper.as_ref().map(|g| g.into_candy_format());
 
+    let price = parse_config_price(&client, &config)?;
+
+    println!("Price {}", price);
+
     let data = CandyMachineData {
         uuid: candy_machine.uuid,
-        price: price_as_lamports(config.price),
+        price,
         symbol: candy_machine.symbol,
         seller_fee_basis_points: candy_machine.seller_fee_basis_points,
         max_supply: 0,

--- a/src/update/process.rs
+++ b/src/update/process.rs
@@ -192,7 +192,7 @@ fn create_candy_machine_data(
 
     let gatekeeper = config.gatekeeper.as_ref().map(|g| g.into_candy_format());
 
-    let price = parse_config_price(&client, &config)?;
+    let price = parse_config_price(client, config)?;
 
     println!("Price {}", price);
 

--- a/src/update/process.rs
+++ b/src/update/process.rs
@@ -194,8 +194,6 @@ fn create_candy_machine_data(
 
     let price = parse_config_price(client, config)?;
 
-    println!("Price {}", price);
-
     let data = CandyMachineData {
         uuid: candy_machine.uuid,
         price,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -39,7 +39,7 @@ pub fn get_cluster(rpc_client: RpcClient) -> Result<Cluster> {
 }
 
 /// Check that the mint token is a valid address.
-pub fn check_spl_token(program: &Program, input: &str) -> Result<()> {
+pub fn check_spl_token(program: &Program, input: &str) -> Result<Mint> {
     let pubkey = Pubkey::from_str(input)?;
     let token_data = program.rpc().get_account_data(&pubkey)?;
     if token_data.len() != 82 {
@@ -48,7 +48,7 @@ pub fn check_spl_token(program: &Program, input: &str) -> Result<()> {
     let token_mint = Mint::unpack_from_slice(&token_data)?;
 
     if token_mint.is_initialized {
-        Ok(())
+        Ok(token_mint)
     } else {
         Err(anyhow!(format!(
             "The specified spl-token is not initialized: {}",


### PR DESCRIPTION
The following changes have been done

1. Remove WL burn authority / SPL transfer authority delegation (approval and revoke) and instead keep the payer as both
2. Fix a bug of price calculation (where it was 10 ^ 9 even for SPL treasury mode), by creating a parser function

### Testing tx - [here](https://explorer.solana.com/tx/347revDkEyLXpftgs8SEL31G9BsszuoV1jhsv3UnxjF52ag56NmCq9iqGT6MU9NpNfKTUaV14x9oiT8WmpXei4Zj?cluster=devnet)

### Token changes screenshot
<img width="1145" alt="Screenshot 2022-05-15 at 2 03 46 AM" src="https://user-images.githubusercontent.com/32637757/168447393-05fa7fc2-85e6-46d9-9a1e-832e49d44a23.png">

The balance changes are as follows
1. NFT token
2. SPL Treasury Token credit
3. WL token burn 
4. SPL Treasury Token debit

Closes #207 