### PR TITLE
style(create-config): add message when loading metatada file

### DIFF
--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -125,20 +125,6 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
         CANDY_EMOJI
     );
 
-    println!(
-        "\n{}",
-        style("Check out our Candy Machine config docs to learn about the options:")
-            .bold()
-            .dim()
-    );
-    println!(
-        "  -> {}\n",
-        style("https://docs.metaplex.com/candy-machine-v2/configuration")
-            .bold()
-            .magenta()
-            .underlined()
-    );
-
     // checks if we have an assets dir and count the number of files
     // assumes 0 in case of error since assets_dir is optional
     let num_files = match count_files(&args.assets_dir) {
@@ -150,6 +136,9 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
     let mut seller_fee = INVALID_SELLER_FEE;
 
     if num_files > 0 {
+        println!("\nFound metadata file(s) in folder '{}':", args.assets_dir);
+        println!("  -> Loading values from file '{}'", DEFAULT_METADATA);
+
         // loads the default values from the first metadata file
         let metadata_file = PathBuf::from(&args.assets_dir)
             .join(DEFAULT_METADATA)
@@ -165,6 +154,15 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
         symbol = metadata.symbol;
         seller_fee = metadata.seller_fee_basis_points;
     }
+
+    println!("\nCheck out our Candy Machine config docs to learn about the options:");
+    println!(
+        "  -> {}\n",
+        style("https://docs.metaplex.com/candy-machine-v2/configuration")
+            .bold()
+            .magenta()
+            .underlined()
+    );
 
     // price
 


### PR DESCRIPTION
Displays a message on the terminal when trying to load the `0.json` metadata file, providing more context if an error occurs at this step.

- with error:
![Screenshot from 2022-05-15 09-05-17](https://user-images.githubusercontent.com/729235/168463304-acc3efd7-7c92-42b1-a91a-64fa3bc87ad1.png)

- without error:
![Screenshot from 2022-05-15 09-01-36](https://user-images.githubusercontent.com/729235/168463255-187ecc72-adb1-433b-b840-cd4068e2b004.png)

