### PR TITLE
fix(upload): added size check for files array property

### DIFF
--- a/src/upload/assets.rs
+++ b/src/upload/assets.rs
@@ -181,9 +181,10 @@ pub fn get_updated_metadata(metadata_file: &str, media_link: &str) -> Result<Str
         serde_json::from_reader(&m)?
     };
 
-    if !metadata.properties.files.is_empty() && metadata.properties.files[0].uri.eq(&metadata.image)
-    {
-        metadata.properties.files[0].uri = media_link.to_string();
+    for file in &mut metadata.properties.files {
+        if file.uri.eq(&metadata.image) {
+            file.uri = media_link.to_string();
+        }
     }
 
     metadata.image = media_link.to_string();

--- a/src/upload/assets.rs
+++ b/src/upload/assets.rs
@@ -181,8 +181,12 @@ pub fn get_updated_metadata(metadata_file: &str, media_link: &str) -> Result<Str
         serde_json::from_reader(&m)?
     };
 
+    if !metadata.properties.files.is_empty() && metadata.properties.files[0].uri.eq(&metadata.image)
+    {
+        metadata.properties.files[0].uri = media_link.to_string();
+    }
+
     metadata.image = media_link.to_string();
-    metadata.properties.files[0].uri = media_link.to_string();
 
     Ok(serde_json::to_string(&metadata).unwrap())
 }


### PR DESCRIPTION
Only updates the `uri` for the `properties.files` if there is one to update.

Fixes #202 