### PR TITLE
NFT Storage as Upload Backend

### DIFF
--- a/src/config/data.rs
+++ b/src/config/data.rs
@@ -64,6 +64,9 @@ pub struct ConfigData {
     #[serde(serialize_with = "to_option_string")]
     pub aws_s3_bucket: Option<String>,
 
+    #[serde(serialize_with = "to_option_string")]
+    pub nft_storage_auth_token: Option<String>,
+
     pub symbol: String,
 
     pub seller_fee_basis_points: u16,
@@ -287,6 +290,7 @@ impl HiddenSettings {
 pub enum UploadMethod {
     Bundlr,
     AWS,
+    NftStorage,
 }
 
 impl Default for UploadMethod {
@@ -302,6 +306,7 @@ impl FromStr for UploadMethod {
         match s.to_lowercase().as_str() {
             "bundlr" => Ok(UploadMethod::Bundlr),
             "aws" => Ok(UploadMethod::AWS),
+            "nft_storage" => Ok(UploadMethod::NftStorage),
             _ => Err(ConfigError::InvalidUploadMethod(s.to_string())),
         }
     }
@@ -312,6 +317,7 @@ impl ToString for UploadMethod {
         match self {
             UploadMethod::Bundlr => "bundlr".to_string(),
             UploadMethod::AWS => "aws".to_string(),
+            UploadMethod::NftStorage => "nft_storage".to_string(),
         }
     }
 }

--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -554,7 +554,7 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
 
     // upload method
 
-    let upload_options = vec!["Bundlr", "AWS"];
+    let upload_options = vec!["Bundlr", "AWS", "NFT Storage"];
     config_data.upload_method = match Select::with_theme(&theme)
         .with_prompt("What upload method do you want to use?")
         .items(&upload_options)
@@ -564,6 +564,7 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
     {
         0 => UploadMethod::Bundlr,
         1 => UploadMethod::AWS,
+        2 => UploadMethod::NftStorage,
         _ => UploadMethod::Bundlr,
     };
 
@@ -571,6 +572,15 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
         config_data.aws_s3_bucket = Some(
             Input::with_theme(&theme)
                 .with_prompt("What is the AWS S3 bucket name?")
+                .interact()
+                .unwrap(),
+        );
+    }
+
+    if config_data.upload_method == UploadMethod::NftStorage {
+        config_data.nft_storage_auth_token = Some(
+            Input::with_theme(&theme)
+                .with_prompt("What is the NFT Storage authentication token?")
                 .interact()
                 .unwrap(),
         );

--- a/src/upload/bundlr.rs
+++ b/src/upload/bundlr.rs
@@ -412,7 +412,12 @@ impl UploadHandler for BundlrHandler {
 
             let cache_item = match cache.items.0.get(&asset_id) {
                 Some(item) => item,
-                None => return Err(anyhow!("Failed to get config item at index {}", asset_id)),
+                None => {
+                    return Err(anyhow::anyhow!(
+                        "Failed to get config item at index: {}",
+                        asset_id
+                    ))
+                }
             };
 
             // todo make sure if failure it should be empty string, this makes it able to be reuploaded if animation present

--- a/src/upload/mod.rs
+++ b/src/upload/mod.rs
@@ -2,10 +2,12 @@ pub mod assets;
 pub mod aws;
 pub mod bundlr;
 pub mod errors;
+pub mod nft_storage;
 pub mod process;
 
 pub use assets::*;
 pub use aws::*;
 pub use bundlr::*;
 pub use errors::*;
+pub use nft_storage::*;
 pub use process::*;

--- a/src/upload/process.rs
+++ b/src/upload/process.rs
@@ -234,6 +234,10 @@ pub async fn process_upload(args: UploadArgs) -> Result<()> {
                 Box::new(AWSHandler::initialize(&get_config_data(&args.config)?).await?)
                     as Box<dyn UploadHandler>
             }
+            UploadMethod::NftStorage => {
+                Box::new(NftStorageHandler::initialize(&get_config_data(&args.config)?).await?)
+                    as Box<dyn UploadHandler>
+            }
         };
 
         pb.finish_with_message("Connected");


### PR DESCRIPTION
### Goal
Candy Machine assets can be saved to [nft.storage](https://nft.storage/).

### Changes
- Add `NftStorage` upload backend
- Store NFT Storage authentication token on sugar config when storage backend selected.

```
[1/4] 🗂  Loading assets
Found 10 image/metadata pair(s), uploading files:
+--------------------+
| images    |     10 |
| metadata  |     10 |
+--------------------+

[2/4] 🖥  Initializing upload
▪▪▪▪▪ Connected

[3/4] 📤 Uploading image files

Sending data: (Ctrl+C to abort)
[00:00:04] Upload successful ███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 10/10

[4/4] 📤 Uploading metadata files

Sending data: (Ctrl+C to abort)
[00:00:02] Upload successful ███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 10/10

10/10 image/metadata pair(s) uploaded.

✅ Command successful.
```