### PR TITLE
Add limit on concurrent uploads

### DIFF
--- a/script/sugar-cli-test.sh
+++ b/script/sugar-cli-test.sh
@@ -73,6 +73,7 @@ function default_settings() {
     INFURA_ID="null"
     INFURA_SECRET="null"
     AWS_BUCKET="null"
+    NFT_STORAGE_TOKEN="null"
 }
 
 function max_settings() {
@@ -90,6 +91,7 @@ function max_settings() {
     INFURA_ID="null"
     INFURA_SECRET="null"
     AWS_BUCKET="null"
+    NFT_STORAGE_TOKEN="null"
 }
 
 function mainnet_env() {
@@ -212,11 +214,13 @@ if [ -z ${STORAGE+x} ]; then
     CYN "Storage type:"
     echo "1. bundlr (default)"
     echo "2. aws"
-    echo  -n "$(CYN "Select the storage type [1-2]") (default 1): "
+    echo "3. NFT Storage"
+    echo  -n "$(CYN "Select the storage type [1-3]") (default 1): "
     read Input
     case "$Input" in
         1) STORAGE="bundlr" ;;
         2) STORAGE="aws" ;;
+        3) STORAGE="nft_storage"
     esac
 fi
 
@@ -247,6 +251,15 @@ if [ -z ${AWS_BUCKET+x} ]; then
     if [ "$STORAGE" = "aws" ]; then
         echo -n $(CYN "AWS bucket name: ")
         read AWS_BUCKET
+    fi
+fi
+
+if [ -z ${NFT_STORAGE_TOKEN+x} ]; then
+    NFT_STORAGE_TOKEN="null"
+
+    if [ "$STORAGE" = "nft_storage" ]; then
+        echo -n $(CYN "Authentication token: ")
+        read NFT_STORAGE_TOKEN
     fi
 fi
 
@@ -539,6 +552,7 @@ cat >$CONFIG_FILE <<-EOM
     "ipfsInfuraProjectId": "${INFURA_ID}",
     "ipfsInfuraSecret": "${INFURA_SECRET}",
     "awsS3Bucket": "${AWS_BUCKET}",
+    "nftStorageAuthToken": "${NFT_STORAGE_TOKEN}",
     "retainAuthority": true,
     "isMutable": true,
     "creators": [
@@ -570,6 +584,7 @@ ARWEAVE_JWK="$ARWEAVE_JWK"
 INFURA_ID="$INFURA_ID"
 INFURA_SECRET="$INFURA_SECRET"
 AWS_BUCKET="$AWS_BUCKET"
+NFT_STORAGE_TOKEN="$NFT_STORAGE_TOKEN"
 
 ENV_URL="$ENV_URL"
 RPC="$RPC"

--- a/src/upload/nft_storage.rs
+++ b/src/upload/nft_storage.rs
@@ -83,6 +83,9 @@ impl NftStorageHandler {
                 StatusCode::OK => Ok(NftStorageHandler {
                     client: Arc::new(client),
                 }),
+                StatusCode::UNAUTHORIZED => {
+                    Err(anyhow!("Invalid nft.storage authentication token."))
+                }
                 code => Err(anyhow!("Could not initialize nft.storage client: {code}")),
             }
         } else {

--- a/src/upload/nft_storage.rs
+++ b/src/upload/nft_storage.rs
@@ -13,11 +13,18 @@ use std::{
         Arc,
     },
 };
+use tokio::time::{sleep, Duration};
 
-use crate::{common::*, config::*, constants::PARALLEL_LIMIT, upload::*, utils::*};
+use crate::{common::*, config::*, upload::*, utils::*};
 
 const NFT_STORAGE_API_URL: &str = "https://api.nft.storage";
 const NFT_STORAGE_GATEWAY_URL: &str = "https://nftstorage.link/ipfs";
+// Request time window (ms) to avoid the rate limit.
+const REQUEST_WAIT: u64 = 1000;
+// Number of concurrent requests.
+const LIMIT: usize = 1;
+// Response timeout (seconds).
+const TIMEOUT: u64 = 20;
 
 pub enum NftStorageError {
     ApiError(Value),
@@ -64,7 +71,10 @@ impl NftStorageHandler {
             auth_value.set_sensitive(true);
             headers.insert(header::AUTHORIZATION, auth_value);
 
-            let client = client_builder.default_headers(headers).build()?;
+            let client = client_builder
+                .default_headers(headers)
+                .timeout(Duration::from_secs(TIMEOUT))
+                .build()?;
 
             Ok(NftStorageHandler {
                 client: Arc::new(client),
@@ -201,7 +211,7 @@ impl UploadHandler for NftStorageHandler {
 
         let mut handles = Vec::new();
 
-        for object in objects.drain(0..cmp::min(objects.len(), PARALLEL_LIMIT)) {
+        for object in objects.drain(0..cmp::min(objects.len(), LIMIT)) {
             let client = self.client.clone();
             handles.push(tokio::spawn(async move {
                 NftStorageHandler::send_to_nft_storage(client, object).await
@@ -249,12 +259,14 @@ impl UploadHandler for NftStorageHandler {
             }
 
             if !objects.is_empty() {
-                // if we are half way through, let spawn more transactions
-                if (PARALLEL_LIMIT - handles.len()) > (PARALLEL_LIMIT / 2) {
+                // if we are done, let spawn more transactions
+                if handles.is_empty() {
                     // syncs cache (checkpoint)
                     cache.sync_file()?;
+                    // minimum gap between request
+                    sleep(Duration::from_millis(REQUEST_WAIT)).await;
 
-                    for object in objects.drain(0..cmp::min(objects.len(), PARALLEL_LIMIT / 2)) {
+                    for object in objects.drain(0..cmp::min(objects.len(), LIMIT)) {
                         let client = self.client.clone();
                         handles.push(tokio::spawn(async move {
                             NftStorageHandler::send_to_nft_storage(client, object).await


### PR DESCRIPTION
This PR adds a limit on the number of concurrent uploads for the `nft_storage` method to avoid reaching the rate limit.