### PR TITLE
feat(logging): add solana-logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2661,9 +2661,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-candy-machine"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fed8c4280024581a6c8a3ca7d18a5103e8c8fd030e2164177b75afe3ab2a488"
+checksum = "113e1468f5d73bc99305a625a322d73ced9aed4388a4a425c4d4f34ae6daf7f7"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -4725,6 +4725,7 @@ dependencies = [
  "shellexpand",
  "solana-account-decoder",
  "solana-client",
+ "solana-logger",
  "solana-program",
  "spl-associated-token-account",
  "spl-token",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ glob = "0.3.0"
 indexmap = { version = "1.8.0", features = ["serde"] }
 indicatif = { version = "0.16.2", features = ["rayon"] }
 mpl-token-metadata = "1.2.7"
-mpl-candy-machine = { version = "4.0.0", features = ["no-entrypoint"] }
+mpl-candy-machine = { version = "4.0.1", features = ["no-entrypoint"] }
 num_cpus = "1.13.1"
 par-stream = { version = "0.10.0", features = ["runtime-tokio"] }
 rand = "0.7.0"
@@ -56,3 +56,4 @@ tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 tracing-bunyan-formatter = "0.3"
 dialoguer = "0.10.0"
 url = "2.2.2"
+solana-logger = "1.8.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,8 @@ async fn main() {
 }
 
 async fn run() -> Result<()> {
+    solana_logger::setup_with_default("solana=info");
+
     let cli = Cli::parse();
 
     let log_level_error: Result<()> = Err(anyhow!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ async fn main() {
 }
 
 async fn run() -> Result<()> {
-    solana_logger::setup_with_default("solana=info");
+    solana_logger::setup_with_default("solana=off");
 
     let cli = Cli::parse();
 


### PR DESCRIPTION
I tested it on a few commands and the default value of `info` doesn't seem to produce messages (which would interrupt our normal std output). If we find it does we can shift the default level to `error` or turn it off by default.