### PR TITLE
feat(show): add option to show and log unminted indices

### DIFF
--- a/src/candy_machine.rs
+++ b/src/candy_machine.rs
@@ -10,10 +10,12 @@ use crate::config::{price_as_lamports, ConfigData};
 use crate::setup::setup_client;
 use crate::utils::check_spl_token;
 
-// To test a custom candy machine program, comment the line above and use the
-// following lines to declare the id to use:
+// To test a custom candy machine program, comment the mpl_candy_machine::ID line
+// above and use the following lines to declare the id to use:
+//
 //use solana_program::declare_id;
-//declare_id!("<CANDY MACHINE ID>");
+//declare_id!("<YOUR CANDY MACHINE ID>");
+//pub use self::ID as CANDY_MACHINE_ID;
 
 #[derive(Debug)]
 pub struct ConfigStatus {
@@ -47,8 +49,9 @@ pub fn get_candy_machine_state(
     program.account(*candy_machine_id).map_err(|e| match e {
         ClientError::AccountNotFound => anyhow!("Candy Machine does not exist!"),
         _ => anyhow!(
-            "Failed to deserialize Candy Machine account: {}",
-            candy_machine_id.to_string()
+            "Failed to deserialize Candy Machine account {}: {}",
+            candy_machine_id.to_string(),
+            e
         ),
     })
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -220,6 +220,10 @@ pub enum Commands {
 
         /// Address of candy machine
         candy_machine: Option<String>,
+
+        /// Display a list of unminted indices
+        #[clap(long)]
+        unminted: bool,
     },
 
     /// Interact with the bundlr network

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,11 +251,13 @@ async fn run() -> Result<()> {
             rpc_url,
             cache,
             candy_machine,
+            unminted,
         } => process_show(ShowArgs {
             keypair,
             rpc_url,
             cache,
             candy_machine,
+            unminted,
         })?,
         Commands::Collection {
             keypair,

--- a/src/show/process.rs
+++ b/src/show/process.rs
@@ -23,6 +23,8 @@ pub struct ShowArgs {
 // TODO: change the value '1' for the corresponding constant once the
 // new version of the mpl_candy_machine crate is published
 const SWAP_REMOVE_FEATURE_INDEX: usize = 1;
+// number of indices per line
+const PER_LINE: usize = 11;
 
 pub fn process_show(args: ShowArgs) -> Result<()> {
     println!(
@@ -235,7 +237,7 @@ pub fn process_show(args: ShowArgs) -> Result<()> {
         println!(
             "\n{} {}Retrieving unminted indices",
             style("[2/2]").bold().dim(),
-            PAPER_EMOJI
+            LOOKING_GLASS_EMOJI
         );
 
         let mut start = CONFIG_ARRAY_START
@@ -285,16 +287,38 @@ pub fn process_show(args: ShowArgs) -> Result<()> {
         }
 
         if !indices.is_empty() {
-            print!("\n{}", style("Indices => [ ").dim());
+            // makes sure all items are in order
+            indices.sort();
+            // logs all indices
+            info!("unminted list: {:?}", indices);
 
-            // prints the first unminted
-            print!("{}", indices.remove(0));
-            // prints the remaining ones
+            println!(
+                "\n{}{}",
+                PAPER_EMOJI,
+                style(format!("Unminted list ({} total):", indices.len())).dim()
+            );
+            let mut current = 0;
+
             for i in indices {
-                print!(", {i}");
-            }
+                if current == 0 {
+                    println!("{}", style(" :").dim());
+                    print!("{}", style(" :.. ").dim());
+                }
+                current += 1;
 
-            println!("{}", style(" ]").dim());
+                print!(
+                    "{:<5}{}",
+                    i,
+                    if current == PER_LINE {
+                        current = 0;
+                        "\n"
+                    } else {
+                        " "
+                    }
+                );
+            }
+            // just adds a new line break
+            println!("");
         }
     }
 

--- a/src/show/process.rs
+++ b/src/show/process.rs
@@ -4,7 +4,7 @@ use anchor_client::solana_sdk::{native_token::LAMPORTS_PER_SOL, pubkey::Pubkey};
 use anyhow::Result;
 use chrono::NaiveDateTime;
 use console::style;
-use mpl_candy_machine::{EndSettingType, WhitelistMintMode};
+use mpl_candy_machine::{utils::is_feature_active, EndSettingType, WhitelistMintMode};
 
 use crate::cache::load_cache;
 use crate::candy_machine::*;
@@ -17,12 +17,21 @@ pub struct ShowArgs {
     pub rpc_url: Option<String>,
     pub cache: String,
     pub candy_machine: Option<String>,
+    pub unminted: bool,
 }
+
+// TODO: change the value '1' for the corresponding constant once the
+// new version of the mpl_candy_machine crate is published
+const SWAP_REMOVE_FEATURE_INDEX: usize = 1;
 
 pub fn process_show(args: ShowArgs) -> Result<()> {
     println!(
         "{} {}Looking up candy machine",
-        style("[1/1]").bold().dim(),
+        if args.unminted {
+            style("[1/2]").bold().dim()
+        } else {
+            style("[1/1]").bold().dim()
+        },
         LOOKING_GLASS_EMOJI
     );
 
@@ -218,6 +227,75 @@ pub fn process_show(args: ShowArgs) -> Result<()> {
         );
     } else {
         print_with_style("", "gatekeeper", "none".to_string());
+    }
+
+    // unminted indices
+
+    if args.unminted {
+        println!(
+            "\n{} {}Retrieving unminted indices",
+            style("[2/2]").bold().dim(),
+            PAPER_EMOJI
+        );
+
+        let mut start = CONFIG_ARRAY_START
+            + STRING_LEN_SIZE
+            + CONFIG_LINE_SIZE * cndy_data.items_available as usize
+            + STRING_LEN_SIZE
+            + cndy_data
+                .items_available
+                .checked_div(8)
+                .expect("Numerical overflow error") as usize
+            + STRING_LEN_SIZE;
+
+        let pb = spinner_with_style();
+        pb.set_message("Connecting...");
+        // retrieve the (raw) candy machine data
+        let data = program.rpc().get_account_data(&candy_machine_id)?;
+
+        pb.finish_and_clear();
+        let mut index = 0;
+        let mut indices = vec![];
+
+        if is_feature_active(&cndy_data.uuid, SWAP_REMOVE_FEATURE_INDEX) {
+            start += 1; // needed to get around rounding precision
+            let remaining = cndy_data.items_available - cndy_state.items_redeemed;
+            for i in 0..remaining {
+                let slice = start + (i * 4) as usize;
+                indices.push(u32::from_le_bytes(
+                    data[slice..slice + 4].try_into().unwrap(),
+                ));
+            }
+        } else {
+            while start < data.len() {
+                let mask = 1u8 << 7;
+
+                for i in 0..8 {
+                    if index < cndy_data.items_available {
+                        // unused mint indices have the 'flag' set to 0
+                        if (data[start] & (mask >> i)) == 0 {
+                            indices.push(index as u32);
+                        }
+                        index += 1;
+                    }
+                }
+
+                start += 1;
+            }
+        }
+
+        if !indices.is_empty() {
+            print!("\n{}", style("Indices => [ ").dim());
+
+            // prints the first unminted
+            print!("{}", indices.remove(0));
+            // prints the remaining ones
+            for i in indices {
+                print!(", {i}");
+            }
+
+            println!("{}", style(" ]").dim());
+        }
     }
 
     Ok(())

--- a/src/show/process.rs
+++ b/src/show/process.rs
@@ -288,7 +288,7 @@ pub fn process_show(args: ShowArgs) -> Result<()> {
 
         if !indices.is_empty() {
             // makes sure all items are in order
-            indices.sort();
+            indices.sort_unstable();
             // logs all indices
             info!("unminted list: {:?}", indices);
 
@@ -318,7 +318,7 @@ pub fn process_show(args: ShowArgs) -> Result<()> {
                 );
             }
             // just adds a new line break
-            println!("");
+            println!();
         }
     }
 


### PR DESCRIPTION
Added `--unminted` flag to `show` command to print and log the list of unminted indices. The list is also logged.
![image](https://user-images.githubusercontent.com/729235/176729264-4304f4f2-a85b-4831-833c-754710d8f07d.png)
