### PR TITLE
allow none in go live date

### DIFF
--- a/src/config/data.rs
+++ b/src/config/data.rs
@@ -98,13 +98,12 @@ pub fn parse_string_as_date(go_live_date: &str) -> Result<String> {
 
 pub fn go_live_date_as_timestamp(go_live_date: &Option<String>) -> Result<Option<i64>> {
     if let Some(go_live_date) = go_live_date {
-        let format;
-        if let Ok(date) = chrono::DateTime::parse_from_rfc2822(go_live_date) {
-            format = date.timestamp();
+        let format = if let Ok(date) = chrono::DateTime::parse_from_rfc2822(go_live_date) {
+            date.timestamp()
         } else if let Ok(date) = chrono::DateTime::parse_from_rfc3339(go_live_date) {
-            format = date.timestamp();
+            date.timestamp()
         } else if let Ok(timestamp) = go_live_date.parse::<i64>() {
-            format = timestamp;
+            timestamp
         } else {
             return Err(anyhow!("Invalid date format. Format must be: RFC2822(Fri, 14 Jul 2022 02:40:00 -0400), RFC3339(2022-02-25T13:00:00Z), or UNIX timestamp."));
         };

--- a/src/config/data.rs
+++ b/src/config/data.rs
@@ -47,7 +47,7 @@ pub struct ConfigData {
     #[serde(serialize_with = "to_option_string")]
     pub spl_token: Option<Pubkey>,
 
-    pub go_live_date: String,
+    pub go_live_date: Option<String>,
 
     pub end_settings: Option<EndSettings>,
 
@@ -96,19 +96,22 @@ pub fn parse_string_as_date(go_live_date: &str) -> Result<String> {
     Ok(date.to_rfc2822())
 }
 
-pub fn go_live_date_as_timestamp(go_live_date: &str) -> Result<i64> {
-    let format;
-    if let Ok(date) = chrono::DateTime::parse_from_rfc2822(go_live_date) {
-        format = date.timestamp();
-    } else if let Ok(date) = chrono::DateTime::parse_from_rfc3339(go_live_date) {
-        format = date.timestamp();
-    } else if let Ok(timestamp) = go_live_date.parse::<i64>() {
-        format = timestamp;
+pub fn go_live_date_as_timestamp(go_live_date: &Option<String>) -> Result<Option<i64>> {
+    if let Some(go_live_date) = go_live_date {
+        let format;
+        if let Ok(date) = chrono::DateTime::parse_from_rfc2822(go_live_date) {
+            format = date.timestamp();
+        } else if let Ok(date) = chrono::DateTime::parse_from_rfc3339(go_live_date) {
+            format = date.timestamp();
+        } else if let Ok(timestamp) = go_live_date.parse::<i64>() {
+            format = timestamp;
+        } else {
+            return Err(anyhow!("Invalid date format. Format must be: RFC2822(Fri, 14 Jul 2022 02:40:00 -0400), RFC3339(2022-02-25T13:00:00Z), or UNIX timestamp."));
+        };
+        Ok(Some(format))
     } else {
-        return Err(anyhow!("Invalid date format. Format must be: RFC2822(Fri, 14 Jul 2022 02:40:00 -0400), RFC3339(2022-02-25T13:00:00Z), or UNIX timestamp."));
-    };
-
-    Ok(format)
+        Ok(None)
+    }
 }
 
 pub fn price_as_lamports(price: f64) -> u64 {

--- a/src/deploy/initialize.rs
+++ b/src/deploy/initialize.rs
@@ -26,7 +26,7 @@ pub fn create_candy_machine_data(
     config: &ConfigData,
     uuid: String,
 ) -> Result<CandyMachineData> {
-    let go_live_date = Some(go_live_date_as_timestamp(&config.go_live_date)?);
+    let go_live_date: Option<i64> = go_live_date_as_timestamp(&config.go_live_date)?;
 
     let end_settings = config.end_settings.as_ref().map(|s| s.into_candy_format());
 

--- a/src/update/process.rs
+++ b/src/update/process.rs
@@ -176,7 +176,7 @@ fn create_candy_machine_data(
     candy_machine: CandyMachineData,
 ) -> Result<CandyMachineData> {
     info!("{:?}", config.go_live_date);
-    let go_live_date = Some(go_live_date_as_timestamp(&config.go_live_date)?);
+    let go_live_date: Option<i64> = go_live_date_as_timestamp(&config.go_live_date)?;
 
     let end_settings = config.end_settings.as_ref().map(|s| s.into_candy_format());
 


### PR DESCRIPTION
Prior to this fix there was no way to set go live date to none using sugar. This adds support in the config creator and in the parser