### PR TITLE
Add rustfmt.toml and reformat imports

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,8 @@
+edition = "2021"
+max_width = 100 
+imports_indent = "Block"
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+reorder_imports = true
+reorder_modules = true
+reorder_impl_items = false

--- a/src/bundlr/process.rs
+++ b/src/bundlr/process.rs
@@ -1,10 +1,12 @@
 use anchor_client::solana_sdk::{native_token::LAMPORTS_PER_SOL, signer::Signer};
-use bundlr_sdk::{deep_hash::deep_hash, deep_hash::DeepHashChunk};
+use bundlr_sdk::deep_hash::{deep_hash, DeepHashChunk};
 use console::style;
 use data_encoding::BASE64URL;
 
-use crate::candy_machine::CANDY_MACHINE_ID;
-use crate::{cli::BundlrAction, common::*, config::*, upload::methods::BundlrMethod, utils::*};
+use crate::{
+    candy_machine::CANDY_MACHINE_ID, cli::BundlrAction, common::*, config::*,
+    upload::methods::BundlrMethod, utils::*,
+};
 
 // The minimum amount required for withdraw.
 const LIMIT: u64 = 5000;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,11 +1,16 @@
-use crate::common::*;
-use crate::pdas::find_candy_machine_creator_pda;
+use std::{
+    fs,
+    io::Write,
+    ops::{Deref, DerefMut},
+    path::Path,
+};
+
 use anchor_client::solana_sdk::pubkey::Pubkey;
 use anyhow::Result;
 use mpl_candy_machine::ConfigLine;
 use serde::{Deserialize, Serialize};
-use std::ops::{Deref, DerefMut};
-use std::{fs, io::Write, path::Path};
+
+use crate::{common::*, pdas::find_candy_machine_creator_pda};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Cache {

--- a/src/candy_machine.rs
+++ b/src/candy_machine.rs
@@ -1,14 +1,14 @@
-use anchor_client::solana_sdk::pubkey::Pubkey;
-use anchor_client::{Client, ClientError};
+use anchor_client::{solana_sdk::pubkey::Pubkey, Client, ClientError};
 use anyhow::{anyhow, Result};
 pub use mpl_candy_machine::ID as CANDY_MACHINE_ID;
 use mpl_candy_machine::{CandyMachine, CandyMachineData, WhitelistMintMode, WhitelistMintSettings};
 use spl_token::id as token_program_id;
 
-use crate::config::data::SugarConfig;
-use crate::config::{price_as_lamports, ConfigData};
-use crate::setup::setup_client;
-use crate::utils::check_spl_token;
+use crate::{
+    config::{data::SugarConfig, price_as_lamports, ConfigData},
+    setup::setup_client,
+    utils::check_spl_token,
+};
 
 // To test a custom candy machine program, comment the line above and use the
 // following lines to declare the id to use:

--- a/src/collections/remove.rs
+++ b/src/collections/remove.rs
@@ -3,17 +3,16 @@ use std::str::FromStr;
 use anchor_client::solana_sdk::pubkey::Pubkey;
 use anyhow::Result;
 use console::style;
-use mpl_candy_machine::accounts as nft_accounts;
-use mpl_candy_machine::instruction as nft_instruction;
-use mpl_token_metadata::pda::find_collection_authority_account;
-use mpl_token_metadata::state::Metadata;
+use mpl_candy_machine::{accounts as nft_accounts, instruction as nft_instruction};
+use mpl_token_metadata::{pda::find_collection_authority_account, state::Metadata};
 
-use crate::cache::load_cache;
-use crate::candy_machine::CANDY_MACHINE_ID;
-use crate::candy_machine::*;
-use crate::common::*;
-use crate::pdas::*;
-use crate::utils::spinner_with_style;
+use crate::{
+    cache::load_cache,
+    candy_machine::{CANDY_MACHINE_ID, *},
+    common::*,
+    pdas::*,
+    utils::spinner_with_style,
+};
 
 pub struct RemoveCollectionArgs {
     pub keypair: Option<String>,

--- a/src/collections/set.rs
+++ b/src/collections/set.rs
@@ -3,18 +3,20 @@ use std::str::FromStr;
 use anchor_client::solana_sdk::{pubkey::Pubkey, system_program, sysvar};
 use anyhow::Result;
 use console::style;
-use mpl_candy_machine::instruction as nft_instruction;
-use mpl_candy_machine::{accounts as nft_accounts, CandyError};
-use mpl_token_metadata::error::MetadataError;
-use mpl_token_metadata::pda::find_collection_authority_account;
-use mpl_token_metadata::state::{MasterEditionV2, Metadata};
+use mpl_candy_machine::{accounts as nft_accounts, instruction as nft_instruction, CandyError};
+use mpl_token_metadata::{
+    error::MetadataError,
+    pda::find_collection_authority_account,
+    state::{MasterEditionV2, Metadata},
+};
 
-use crate::cache::load_cache;
-use crate::candy_machine::CANDY_MACHINE_ID;
-use crate::candy_machine::*;
-use crate::common::*;
-use crate::pdas::*;
-use crate::utils::spinner_with_style;
+use crate::{
+    cache::load_cache,
+    candy_machine::{CANDY_MACHINE_ID, *},
+    common::*,
+    pdas::*,
+    utils::spinner_with_style,
+};
 
 pub struct SetCollectionArgs {
     pub collection_mint: String,

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,10 @@
+pub use std::{
+    collections::HashMap,
+    fs::File,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
 pub use anchor_client::{
     solana_sdk::{
         commitment_config::CommitmentConfig,
@@ -12,23 +19,19 @@ pub use anchor_lang::AccountDeserialize;
 pub use anyhow::{anyhow, Result};
 pub use bs58;
 pub use indexmap::IndexMap;
+pub use mpl_candy_machine::{
+    accounts as nft_accounts, instruction as nft_instruction, CandyMachine, WhitelistMintMode,
+    ID as CANDY_MACHINE_PROGRAM_ID,
+};
 pub use reqwest::{Client as HttpClient, Response};
 pub use serde::Deserialize;
 pub use serde_json::{json, Value};
-pub use std::{
-    collections::HashMap,
-    fs::File,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
 pub use tracing::{debug, error, info, warn};
 
-pub use mpl_candy_machine::accounts as nft_accounts;
-pub use mpl_candy_machine::instruction as nft_instruction;
-pub use mpl_candy_machine::{CandyMachine, WhitelistMintMode, ID as CANDY_MACHINE_PROGRAM_ID};
-
-pub use crate::cache::{Cache, CacheItem};
-pub use crate::constants::*;
-pub use crate::errors::*;
-pub use crate::parse::path_to_string;
-pub use crate::setup::{setup_client, sugar_setup};
+pub use crate::{
+    cache::{Cache, CacheItem},
+    constants::*,
+    errors::*,
+    parse::path_to_string,
+    setup::{setup_client, sugar_setup},
+};

--- a/src/config/data.rs
+++ b/src/config/data.rs
@@ -1,17 +1,20 @@
-use anchor_client::solana_sdk::signature::Keypair;
-use anchor_client::solana_sdk::{native_token::LAMPORTS_PER_SOL, pubkey::Pubkey};
+use std::{
+    fmt::{self, Display},
+    str::FromStr,
+};
+
+use anchor_client::solana_sdk::{
+    native_token::LAMPORTS_PER_SOL, pubkey::Pubkey, signature::Keypair,
+};
 pub use anyhow::{anyhow, Result};
 use chrono::DateTime;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt::{self, Display};
-use std::str::FromStr;
-
 use mpl_candy_machine::{
     Creator as CandyCreator, EndSettingType as CandyEndSettingType,
     EndSettings as CandyEndSettings, GatekeeperConfig as CandyGatekeeperConfig,
     HiddenSettings as CandyHiddenSettings, WhitelistMintMode as CandyWhitelistMintMode,
     WhitelistMintSettings as CandyWhitelistMintSettings,
 };
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::config::errors::*;
 

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -1,11 +1,12 @@
+use std::{
+    fs::{metadata, OpenOptions},
+    io::ErrorKind,
+};
+
 use anyhow::Result;
-use std::fs::metadata;
-use std::fs::OpenOptions;
-use std::io::ErrorKind;
 use tracing::error;
 
-use crate::config::data::*;
-use crate::config::errors::ConfigError;
+use crate::config::{data::*, errors::ConfigError};
 
 pub fn get_config_data(config_path: &str) -> Result<ConfigData, ConfigError> {
     // checks that the config file exists and it is readable

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,8 +1,7 @@
+use console::Emoji;
 pub use mpl_token_metadata::state::{
     MAX_CREATOR_LEN, MAX_CREATOR_LIMIT, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH,
 };
-
-use console::Emoji;
 
 /// Metaplex program id.
 pub const METAPLEX_PROGRAM_ID: &str = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s";

--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -1,9 +1,3 @@
-use anchor_lang::prelude::Pubkey;
-use anyhow::{anyhow, Result};
-use chrono::DateTime;
-use console::style;
-use dialoguer::Confirm;
-use dialoguer::{Input, MultiSelect, Select};
 use std::{
     default::Default,
     fs::{File, OpenOptions},
@@ -11,18 +5,26 @@ use std::{
     str::FromStr,
     sync::Arc,
 };
+
+use anchor_lang::prelude::Pubkey;
+use anyhow::{anyhow, Result};
+use chrono::DateTime;
+use console::style;
+use dialoguer::{Confirm, Input, MultiSelect, Select};
 use url::Url;
 
-use crate::candy_machine::CANDY_MACHINE_ID;
-use crate::config::{
-    parse_string_as_date, ConfigData, Creator, EndSettingType, EndSettings, GatekeeperConfig,
-    HiddenSettings, UploadMethod, WhitelistMintMode, WhitelistMintSettings,
+use crate::{
+    candy_machine::CANDY_MACHINE_ID,
+    config::{
+        parse_string_as_date, ConfigData, Creator, EndSettingType, EndSettings, GatekeeperConfig,
+        HiddenSettings, UploadMethod, WhitelistMintMode, WhitelistMintSettings,
+    },
+    constants::*,
+    setup::{setup_client, sugar_setup},
+    upload::list_files,
+    utils::{check_spl_token, check_spl_token_account, get_dialoguer_theme},
+    validate::Metadata,
 };
-use crate::constants::*;
-use crate::setup::{setup_client, sugar_setup};
-use crate::upload::list_files;
-use crate::utils::{check_spl_token, check_spl_token_account, get_dialoguer_theme};
-use crate::validate::Metadata;
 
 /// Default name of the first metadata file.
 const DEFAULT_METADATA: &str = "0.json";

--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -10,20 +10,21 @@ use anchor_lang::prelude::Pubkey;
 use anyhow::{anyhow, Result};
 use chrono::DateTime;
 use console::style;
-use dialoguer::Confirm;
-use dialoguer::{Input, MultiSelect, Select};
+use dialoguer::{Confirm, Input, MultiSelect, Select};
 use url::Url;
 
-use crate::candy_machine::CANDY_MACHINE_ID;
-use crate::config::{
-    parse_string_as_date, ConfigData, Creator, EndSettingType, EndSettings, GatekeeperConfig,
-    HiddenSettings, UploadMethod, WhitelistMintMode, WhitelistMintSettings,
+use crate::{
+    candy_machine::CANDY_MACHINE_ID,
+    config::{
+        parse_string_as_date, ConfigData, Creator, EndSettingType, EndSettings, GatekeeperConfig,
+        HiddenSettings, UploadMethod, WhitelistMintMode, WhitelistMintSettings,
+    },
+    constants::*,
+    setup::{setup_client, sugar_setup},
+    upload::list_files,
+    utils::{check_spl_token, check_spl_token_account, get_dialoguer_theme},
+    validate::Metadata,
 };
-use crate::constants::*;
-use crate::setup::{setup_client, sugar_setup};
-use crate::upload::list_files;
-use crate::utils::{check_spl_token, check_spl_token_account, get_dialoguer_theme};
-use crate::validate::Metadata;
 
 /// Default name of the first metadata file.
 const DEFAULT_METADATA: &str = "0.json";

--- a/src/deploy/collection.rs
+++ b/src/deploy/collection.rs
@@ -1,16 +1,22 @@
 use anchor_client::{solana_sdk::pubkey::Pubkey, Client};
 use anyhow::Result;
-use mpl_token_metadata::instruction::{create_master_edition_v3, create_metadata_accounts_v2};
-use mpl_token_metadata::pda::find_collection_authority_account;
-use mpl_token_metadata::state::Creator;
+use mpl_token_metadata::{
+    instruction::{create_master_edition_v3, create_metadata_accounts_v2},
+    pda::find_collection_authority_account,
+    state::Creator,
+};
 use spl_associated_token_account::{create_associated_token_account, get_associated_token_address};
-use spl_token::instruction::mint_to;
-use spl_token::{instruction::initialize_mint, ID as TOKEN_PROGRAM_ID};
+use spl_token::{
+    instruction::{initialize_mint, mint_to},
+    ID as TOKEN_PROGRAM_ID,
+};
 
-use crate::candy_machine::CANDY_MACHINE_ID;
-use crate::common::*;
-use crate::config::ConfigData;
-use crate::pdas::{find_collection_pda, find_master_edition_pda, find_metadata_pda};
+use crate::{
+    candy_machine::CANDY_MACHINE_ID,
+    common::*,
+    config::ConfigData,
+    pdas::{find_collection_pda, find_master_edition_pda, find_metadata_pda},
+};
 
 pub fn create_and_set_collection(
     client: Client,

--- a/src/deploy/config_lines.rs
+++ b/src/deploy/config_lines.rs
@@ -10,20 +10,15 @@ use anchor_client::solana_sdk::{pubkey::Pubkey, signature::Keypair};
 use anyhow::Result;
 use console::style;
 use futures::future::select_all;
-use mpl_candy_machine::accounts as nft_accounts;
-use mpl_candy_machine::instruction as nft_instruction;
-use mpl_candy_machine::ConfigLine;
+use mpl_candy_machine::{accounts as nft_accounts, instruction as nft_instruction, ConfigLine};
 pub use mpl_token_metadata::state::{
     MAX_CREATOR_LIMIT, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH,
 };
 
-use crate::cache::*;
-use crate::candy_machine::CANDY_MACHINE_ID;
-use crate::common::*;
-use crate::config::data::*;
-use crate::deploy::errors::*;
-use crate::setup::setup_client;
-use crate::utils::*;
+use crate::{
+    cache::*, candy_machine::CANDY_MACHINE_ID, common::*, config::data::*, deploy::errors::*,
+    setup::setup_client, utils::*,
+};
 
 /// The maximum config line bytes per transaction.
 const MAX_TRANSACTION_BYTES: usize = 1000;

--- a/src/deploy/initialize.rs
+++ b/src/deploy/initialize.rs
@@ -5,20 +5,16 @@ use anchor_client::solana_sdk::{
 };
 use anchor_lang::prelude::AccountMeta;
 use anyhow::Result;
-
-use solana_program::native_token::LAMPORTS_PER_SOL;
-
-use mpl_candy_machine::accounts as nft_accounts;
-use mpl_candy_machine::instruction as nft_instruction;
-use mpl_candy_machine::{CandyMachineData, Creator as CandyCreator};
+use mpl_candy_machine::{
+    accounts as nft_accounts, instruction as nft_instruction, CandyMachineData,
+    Creator as CandyCreator,
+};
 pub use mpl_token_metadata::state::{
     MAX_CREATOR_LIMIT, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH,
 };
+use solana_program::native_token::LAMPORTS_PER_SOL;
 
-use crate::candy_machine::parse_config_price;
-use crate::common::*;
-use crate::config::data::*;
-use crate::deploy::errors::*;
+use crate::{candy_machine::parse_config_price, common::*, config::data::*, deploy::errors::*};
 
 /// Create the candy machine data struct.
 pub fn create_candy_machine_data(

--- a/src/deploy/process.rs
+++ b/src/deploy/process.rs
@@ -17,18 +17,19 @@ use console::style;
 use rand::rngs::OsRng;
 use spl_associated_token_account::get_associated_token_address;
 
-use crate::cache::*;
-use crate::candy_machine::{get_candy_machine_state, CANDY_MACHINE_ID};
-use crate::common::*;
-use crate::config::parser::get_config_data;
-use crate::deploy::errors::*;
-use crate::deploy::{
-    create_and_set_collection, create_candy_machine_data, generate_config_lines,
-    initialize_candy_machine, upload_config_lines,
+use crate::{
+    cache::*,
+    candy_machine::{get_candy_machine_state, CANDY_MACHINE_ID},
+    common::*,
+    config::parser::get_config_data,
+    deploy::{
+        create_and_set_collection, create_candy_machine_data, errors::*, generate_config_lines,
+        initialize_candy_machine, upload_config_lines,
+    },
+    setup::{setup_client, sugar_setup},
+    utils::*,
+    validate::parser::{check_name, check_seller_fee_basis_points, check_symbol, check_url},
 };
-use crate::setup::{setup_client, sugar_setup};
-use crate::utils::*;
-use crate::validate::parser::{check_name, check_seller_fee_basis_points, check_symbol, check_url};
 
 pub struct DeployArgs {
     pub config: String,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/src/launch/process.rs
+++ b/src/launch/process.rs
@@ -1,16 +1,18 @@
-use anyhow::Result;
-use console::{style, Style};
-use dialoguer::theme::ColorfulTheme;
-use dialoguer::Confirm;
 use std::sync::{atomic::AtomicBool, Arc};
 
-use crate::common::LAUNCH_EMOJI;
-use crate::config::parser::get_config_data;
-use crate::create_config::{process_create_config, CreateConfigArgs};
-use crate::deploy::{process_deploy, DeployArgs};
-use crate::upload::{process_upload, UploadArgs};
-use crate::validate::{process_validate, ValidateArgs};
-use crate::verify::{process_verify, VerifyArgs};
+use anyhow::Result;
+use console::{style, Style};
+use dialoguer::{theme::ColorfulTheme, Confirm};
+
+use crate::{
+    common::LAUNCH_EMOJI,
+    config::parser::get_config_data,
+    create_config::{process_create_config, CreateConfigArgs},
+    deploy::{process_deploy, DeployArgs},
+    upload::{process_upload, UploadArgs},
+    validate::{process_validate, ValidateArgs},
+    verify::{process_verify, VerifyArgs},
+};
 
 pub struct LaunchArgs {
     pub assets_dir: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,26 +11,27 @@ use std::{
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use console::style;
+use sugar_cli::{
+    bundlr::{process_bundlr, BundlrArgs},
+    cli::{Cli, CollectionSubcommands, Commands},
+    collections::{
+        process_remove_collection, process_set_collection, RemoveCollectionArgs, SetCollectionArgs,
+    },
+    constants::{COMPLETE_EMOJI, ERROR_EMOJI},
+    create_config::{process_create_config, CreateConfigArgs},
+    deploy::{process_deploy, DeployArgs},
+    launch::{process_launch, LaunchArgs},
+    mint::{process_mint, MintArgs},
+    show::{process_show, ShowArgs},
+    update::{process_update, UpdateArgs},
+    upload::{process_upload, UploadArgs},
+    validate::{process_validate, ValidateArgs},
+    verify::{process_verify, VerifyArgs},
+    withdraw::{process_withdraw, WithdrawArgs},
+};
 use tracing::subscriber::set_global_default;
 use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
 use tracing_subscriber::{self, filter::LevelFilter, prelude::*, EnvFilter};
-
-use sugar_cli::bundlr::{process_bundlr, BundlrArgs};
-use sugar_cli::cli::{Cli, CollectionSubcommands, Commands};
-use sugar_cli::collections::{
-    process_remove_collection, process_set_collection, RemoveCollectionArgs, SetCollectionArgs,
-};
-use sugar_cli::constants::{COMPLETE_EMOJI, ERROR_EMOJI};
-use sugar_cli::create_config::{process_create_config, CreateConfigArgs};
-use sugar_cli::deploy::{process_deploy, DeployArgs};
-use sugar_cli::launch::{process_launch, LaunchArgs};
-use sugar_cli::mint::{process_mint, MintArgs};
-use sugar_cli::show::{process_show, ShowArgs};
-use sugar_cli::update::{process_update, UpdateArgs};
-use sugar_cli::upload::{process_upload, UploadArgs};
-use sugar_cli::validate::{process_validate, ValidateArgs};
-use sugar_cli::verify::{process_verify, VerifyArgs};
-use sugar_cli::withdraw::{process_withdraw, WithdrawArgs};
 
 fn setup_logging(level: Option<EnvFilter>) -> Result<()> {
     // Log path; change this to be dynamic for multiple OSes.

--- a/src/mint/process.rs
+++ b/src/mint/process.rs
@@ -13,9 +13,10 @@ use anchor_lang::prelude::AccountMeta;
 use anyhow::Result;
 use chrono::Utc;
 use console::style;
-use mpl_candy_machine::instruction as nft_instruction;
-use mpl_candy_machine::{accounts as nft_accounts, CollectionPDA};
-use mpl_candy_machine::{CandyError, CandyMachine, EndSettingType, WhitelistMintMode};
+use mpl_candy_machine::{
+    accounts as nft_accounts, instruction as nft_instruction, CandyError, CandyMachine,
+    CollectionPDA, EndSettingType, WhitelistMintMode,
+};
 use mpl_token_metadata::pda::find_collection_authority_account;
 use solana_client::rpc_response::Response;
 use spl_associated_token_account::{create_associated_token_account, get_associated_token_address};
@@ -25,13 +26,14 @@ use spl_token::{
     ID as TOKEN_PROGRAM_ID,
 };
 
-use crate::cache::load_cache;
-use crate::candy_machine::CANDY_MACHINE_ID;
-use crate::candy_machine::*;
-use crate::common::*;
-use crate::config::Cluster;
-use crate::pdas::*;
-use crate::utils::*;
+use crate::{
+    cache::load_cache,
+    candy_machine::{CANDY_MACHINE_ID, *},
+    common::*,
+    config::Cluster,
+    pdas::*,
+    utils::*,
+};
 
 pub struct MintArgs {
     pub keypair: Option<String>,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,5 +1,6 @@
-use anyhow::{anyhow, Result};
 use std::{env, fs::File, path::Path};
+
+use anyhow::{anyhow, Result};
 
 use crate::config::data::*;
 

--- a/src/pdas.rs
+++ b/src/pdas.rs
@@ -1,11 +1,12 @@
-use anchor_client::solana_sdk::pubkey::Pubkey;
-use anchor_client::{ClientError, Program};
+use anchor_client::{solana_sdk::pubkey::Pubkey, ClientError, Program};
 use anyhow::{anyhow, Result};
 use mpl_candy_machine::CollectionPDA;
-use mpl_token_metadata::deser::meta_deser;
-use mpl_token_metadata::pda::{find_master_edition_account, find_metadata_account};
-use mpl_token_metadata::state::{Key, MasterEditionV2, Metadata, MAX_MASTER_EDITION_LEN};
-use mpl_token_metadata::utils::try_from_slice_checked;
+use mpl_token_metadata::{
+    deser::meta_deser,
+    pda::{find_master_edition_account, find_metadata_account},
+    state::{Key, MasterEditionV2, Metadata, MAX_MASTER_EDITION_LEN},
+    utils::try_from_slice_checked,
+};
 
 use crate::candy_machine::CANDY_MACHINE_ID;
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use anchor_client::{
     solana_sdk::{
         commitment_config::CommitmentConfig,
@@ -6,12 +8,13 @@ use anchor_client::{
     Client, Cluster,
 };
 use anyhow::{anyhow, Result};
-use std::rc::Rc;
 use tracing::error;
 
-use crate::config::data::SugarConfig;
-use crate::constants::{DEFAULT_KEYPATH, DEFAULT_RPC_DEVNET};
-use crate::parse::*;
+use crate::{
+    config::data::SugarConfig,
+    constants::{DEFAULT_KEYPATH, DEFAULT_RPC_DEVNET},
+    parse::*,
+};
 
 pub fn setup_client(sugar_config: &SugarConfig) -> Result<Client> {
     let rpc_url = sugar_config.rpc_url.clone();

--- a/src/show/process.rs
+++ b/src/show/process.rs
@@ -6,11 +6,7 @@ use chrono::NaiveDateTime;
 use console::style;
 use mpl_candy_machine::{EndSettingType, WhitelistMintMode};
 
-use crate::cache::load_cache;
-use crate::candy_machine::*;
-use crate::common::*;
-use crate::pdas::get_collection_pda;
-use crate::utils::*;
+use crate::{cache::load_cache, candy_machine::*, common::*, pdas::get_collection_pda, utils::*};
 
 pub struct ShowArgs {
     pub keypair: Option<String>,

--- a/src/update/process.rs
+++ b/src/update/process.rs
@@ -1,19 +1,24 @@
+use std::str::FromStr;
+
 use anchor_client::solana_sdk::pubkey::Pubkey;
 use anchor_lang::prelude::AccountMeta;
 use anyhow::Result;
 use console::style;
+use mpl_candy_machine::{
+    accounts as nft_accounts, instruction as nft_instruction, CandyMachineData,
+};
 use spl_associated_token_account::get_associated_token_address;
-use std::str::FromStr;
 
-use mpl_candy_machine::instruction as nft_instruction;
-use mpl_candy_machine::{accounts as nft_accounts, CandyMachineData};
-
-use crate::candy_machine::CANDY_MACHINE_ID;
-use crate::candy_machine::{get_candy_machine_state, parse_config_price};
-use crate::common::*;
-use crate::config::{data::*, parser::get_config_data};
-use crate::utils::{check_spl_token, check_spl_token_account, spinner_with_style};
-use crate::{cache::load_cache, config::data::ConfigData};
+use crate::{
+    cache::load_cache,
+    candy_machine::{get_candy_machine_state, parse_config_price, CANDY_MACHINE_ID},
+    common::*,
+    config::{
+        data::{ConfigData, *},
+        parser::get_config_data,
+    },
+    utils::{check_spl_token, check_spl_token_account, spinner_with_style},
+};
 
 pub struct UpdateArgs {
     pub keypair: Option<String>,

--- a/src/upload/assets.rs
+++ b/src/upload/assets.rs
@@ -1,5 +1,5 @@
-use std::ffi::OsStr;
 use std::{
+    ffi::OsStr,
     fs::{self, DirEntry, File, OpenOptions},
     io::{BufReader, Read},
     sync::Arc,
@@ -13,8 +13,7 @@ use ring::digest::{Context, SHA256};
 use serde::Serialize;
 use serde_json;
 
-use crate::common::*;
-use crate::validate::format::Metadata;
+use crate::{common::*, validate::format::Metadata};
 
 pub struct UploadDataArgs<'a> {
     pub bundlr_client: Arc<Bundlr<SolanaSigner>>,

--- a/src/upload/methods/aws.rs
+++ b/src/upload/methods/aws.rs
@@ -1,14 +1,18 @@
+use std::{fs, sync::Arc};
+
 use async_trait::async_trait;
 use aws_sdk_s3::{types::ByteStream, Client};
 use bs58;
-use std::{fs, sync::Arc};
 use tokio::task::JoinHandle;
 
-use crate::upload::{
-    assets::{AssetPair, DataType},
-    uploader::{AssetInfo, ParallelUploader, Prepare},
+use crate::{
+    common::*,
+    config::*,
+    upload::{
+        assets::{AssetPair, DataType},
+        uploader::{AssetInfo, ParallelUploader, Prepare},
+    },
 };
-use crate::{common::*, config::*};
 
 pub struct AWSMethod {
     pub aws_client: Arc<Client>,

--- a/src/upload/methods/bundlr.rs
+++ b/src/upload/methods/bundlr.rs
@@ -1,17 +1,18 @@
+use std::{cmp, fs, path::Path, sync::Arc};
+
 use anchor_client::solana_sdk::native_token::LAMPORTS_PER_SOL;
 use async_trait::async_trait;
 use bundlr_sdk::{tags::Tag, Bundlr, SolanaSigner};
 use clap::crate_version;
 use console::style;
 use solana_client::rpc_client::RpcClient;
-use std::{cmp, fs, path::Path, sync::Arc};
 use tokio::{
     task::JoinHandle,
     time::{sleep, Duration},
 };
 
-use crate::candy_machine::CANDY_MACHINE_ID;
 use crate::{
+    candy_machine::CANDY_MACHINE_ID,
     common::*,
     config::*,
     upload::{

--- a/src/upload/methods/nft_storage.rs
+++ b/src/upload/methods/nft_storage.rs
@@ -1,9 +1,3 @@
-use async_trait::async_trait;
-use reqwest::{
-    header,
-    multipart::{Form, Part},
-    Client, StatusCode,
-};
 use std::{
     fs,
     path::Path,
@@ -11,6 +5,13 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
+};
+
+use async_trait::async_trait;
+use reqwest::{
+    header,
+    multipart::{Form, Part},
+    Client, StatusCode,
 };
 use tokio::time::{sleep, Duration};
 

--- a/src/upload/process.rs
+++ b/src/upload/process.rs
@@ -1,4 +1,3 @@
-use console::style;
 use std::{
     borrow::Borrow,
     collections::HashSet,
@@ -10,12 +9,16 @@ use std::{
     },
 };
 
-use crate::cache::{load_cache, Cache};
-use crate::common::*;
-use crate::config::{get_config_data, SugarConfig};
-use crate::upload::*;
-use crate::utils::*;
-use crate::validate::format::Metadata;
+use console::style;
+
+use crate::{
+    cache::{load_cache, Cache},
+    common::*,
+    config::{get_config_data, SugarConfig},
+    upload::*,
+    utils::*,
+    validate::format::Metadata,
+};
 
 pub struct UploadArgs {
     pub assets_dir: String,

--- a/src/upload/uploader.rs
+++ b/src/upload/uploader.rs
@@ -1,25 +1,28 @@
-use anyhow::Result;
-use async_trait::async_trait;
-use console::style;
-use futures::future::select_all;
-pub use indicatif::ProgressBar;
-use std::collections::HashMap;
 use std::{
     cmp,
+    collections::HashMap,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
 };
+
+use anyhow::Result;
+use async_trait::async_trait;
+use console::style;
+use futures::future::select_all;
+pub use indicatif::ProgressBar;
 use tokio::task::JoinHandle;
 
-use crate::cache::Cache;
-use crate::config::{ConfigData, SugarConfig, UploadMethod};
-use crate::constants::PARALLEL_LIMIT;
-use crate::upload::{
-    assets::{AssetPair, DataType},
-    methods::*,
-    UploadError,
+use crate::{
+    cache::Cache,
+    config::{ConfigData, SugarConfig, UploadMethod},
+    constants::PARALLEL_LIMIT,
+    upload::{
+        assets::{AssetPair, DataType},
+        methods::*,
+        UploadError,
+    },
 };
 
 // Size of the mock media URI for cost calculations.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,5 @@
+use std::{str::FromStr, thread::sleep, time::Duration};
+
 pub use anchor_client::solana_sdk::hash::Hash;
 use anchor_client::{
     solana_sdk::{
@@ -12,9 +14,6 @@ use dialoguer::theme::ColorfulTheme;
 pub use indicatif::{ProgressBar, ProgressStyle};
 use solana_client::rpc_client::RpcClient;
 use spl_token::state::{Account, Mint};
-use std::str::FromStr;
-use std::thread::sleep;
-use std::time::Duration;
 
 use crate::config::data::Cluster;
 

--- a/src/validate/process.rs
+++ b/src/validate/process.rs
@@ -1,18 +1,16 @@
-use anyhow::Result;
-use console::{style, Style};
-use dialoguer::theme::ColorfulTheme;
-use dialoguer::Confirm;
-use glob::glob;
-use rayon::prelude::*;
 use std::{
     fs::File,
     path::Path,
     sync::{Arc, Mutex},
 };
 
-use crate::common::*;
-use crate::utils::*;
-use crate::validate::*;
+use anyhow::Result;
+use console::{style, Style};
+use dialoguer::{theme::ColorfulTheme, Confirm};
+use glob::glob;
+use rayon::prelude::*;
+
+use crate::{common::*, utils::*, validate::*};
 
 pub struct ValidateArgs {
     pub assets_dir: String,

--- a/src/verify/process.rs
+++ b/src/verify/process.rs
@@ -1,17 +1,19 @@
-use anchor_lang::AccountDeserialize;
-use console::style;
 use std::{thread, time::Duration};
 
+use anchor_lang::AccountDeserialize;
+use console::style;
 use mpl_candy_machine::CandyMachine;
 
-use crate::cache::*;
-use crate::candy_machine::CANDY_MACHINE_ID;
-use crate::common::*;
-use crate::config::Cluster;
-use crate::constants::{CANDY_EMOJI, PAPER_EMOJI};
-use crate::pdas::get_collection_pda;
-use crate::utils::*;
-use crate::verify::VerifyError;
+use crate::{
+    cache::*,
+    candy_machine::CANDY_MACHINE_ID,
+    common::*,
+    config::Cluster,
+    constants::{CANDY_EMOJI, PAPER_EMOJI},
+    pdas::get_collection_pda,
+    utils::*,
+    verify::VerifyError,
+};
 
 pub struct VerifyArgs {
     pub keypair: Option<String>,

--- a/src/withdraw/process.rs
+++ b/src/withdraw/process.rs
@@ -1,3 +1,9 @@
+use std::{
+    io::{stdin, stdout, Write},
+    rc::Rc,
+    str::FromStr,
+};
+
 pub use anchor_client::{
     solana_sdk::{
         commitment_config::{CommitmentConfig, CommitmentLevel},
@@ -10,24 +16,19 @@ pub use anchor_client::{
     Client, Program,
 };
 use console::style;
+use mpl_candy_machine::{accounts as nft_accounts, instruction as nft_instruction};
 use solana_account_decoder::UiAccountEncoding;
 use solana_client::{
     rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
     rpc_filter::{Memcmp, MemcmpEncodedBytes, RpcFilterType},
 };
-use std::{
-    io::{stdin, stdout, Write},
-    rc::Rc,
-    str::FromStr,
+
+use crate::{
+    candy_machine::CANDY_MACHINE_ID,
+    common::*,
+    setup::{setup_client, sugar_setup},
+    utils::*,
 };
-
-use mpl_candy_machine::accounts as nft_accounts;
-use mpl_candy_machine::instruction as nft_instruction;
-
-use crate::candy_machine::CANDY_MACHINE_ID;
-use crate::common::*;
-use crate::setup::{setup_client, sugar_setup};
-use crate::utils::*;
 
 pub struct WithdrawArgs {
     pub candy_machine: Option<String>,


### PR DESCRIPTION
This adds a currently unstable nightly feature of rustfmt. It is currently basically stable. For this I believe we should still add this is and modify the github actions to use nightly for the formatting job. It is very easy to do this locally. Just running `rustup override set nightly`, `cargo fmt --all`, and then resetting the toolchain with `rustup ovverride unset` should allow quick formatting fixes to comply with this. I think it is overall beneficial for consistency's sake. 