### PR TITLE
Fix: sugar collection set arguments

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -268,7 +268,6 @@ pub enum CollectionSubcommands {
     /// Set the collection mint on the candy machine
     Set {
         /// Address of collection mint to set the candy machine to.
-        #[clap(long)]
         collection_mint: String,
     },
 


### PR DESCRIPTION
Removes the clap macro. Didn't realize this was possible before

Before: 
```bash
sugar collection set --collection-mint <MintId>
```

After: 
```bash
sugar collection set <MintId>
```