### PR TITLE
chore: enable windows executable build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os:
-          # - windows-latest
+          - windows-latest
           - ubuntu-latest
           - macos-latest
 


### PR DESCRIPTION
Enables Windows executable build so I can start testing Sugar on Windows.