### PR TITLE
ci(script): deploy install script to gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,25 @@
+name: Deploy Install Script to GitHub Pages
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy-install-script:
+    concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Build 🔧
+        run: |
+          mkdir build
+          cp ./script/sugar-install.sh ./build/install.sh
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: build # The folder the action should deploy.


### PR DESCRIPTION
This PR automates the deploy of `sugar-install.sh` to GitHub pages (`gh-pages` branch).

The install script is available at https://sugar.metaplex.com/install.sh after a successful deploy.