### PR TITLE
ci(script): only run deploy action on file changes

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths: 
+      - 'script/sugar-install.sh'
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
Follow up to PR https://github.com/metaplex-foundation/sugar/pull/264

This PR prevents unnecessary github action runs by filtering by file path