### PR TITLE
fix(show): add message when all items are minted

### DIFF
--- a/src/show/process.rs
+++ b/src/show/process.rs
@@ -282,7 +282,13 @@ pub fn process_show(args: ShowArgs) -> Result<()> {
             }
         }
 
-        if !indices.is_empty() {
+        if indices.is_empty() {
+            println!(
+                "\n{}{}",
+                PAPER_EMOJI,
+                style("All items of the candy machine have been minted.").dim()
+            );
+        } else {
             // makes sure all items are in order
             indices.sort_unstable();
             // logs all indices


### PR DESCRIPTION
Added a message to indicate that all items are minted – the current behaviour just shows a blank line:

<img width="682" alt="image" src="https://user-images.githubusercontent.com/729235/178534392-e729b026-4c0b-469d-8d56-7b247182fd82.png">
