### PR TITLE
refactor(collection): fix bugs; move options to subcommand

### DIFF
--- a/script/sugar-cli-test.sh
+++ b/script/sugar-cli-test.sh
@@ -793,7 +793,7 @@ if [ ! "$MANUAL_CACHE" == "Y" ]; then
     echo ""
 
     MAG "Removing collection >>>"
-    $SUGAR_BIN collection --keypair $WALLET_KEY --cache $CACHE_FILE -r $RPC remove
+    $SUGAR_BIN collection remove --keypair $WALLET_KEY --cache $CACHE_FILE -r $RPC
     MAG "<<<"
 
     # checking that the collection PDA was removed
@@ -806,7 +806,7 @@ if [ ! "$MANUAL_CACHE" == "Y" ]; then
 
     echo ""
     MAG "Setting collection >>>"
-    $SUGAR_BIN collection --keypair $WALLET_KEY --cache $CACHE_FILE -r $RPC set $COLLECTION_PDA
+    $SUGAR_BIN collection set --keypair $WALLET_KEY --cache $CACHE_FILE -r $RPC $COLLECTION_PDA
     MAG "<<<"
 
     # checking that the collection PDA was set

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -242,6 +242,15 @@ pub enum Commands {
 
     /// Manage the collection on the candy machine
     Collection {
+        #[clap(subcommand)]
+        command: CollectionSubcommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum CollectionSubcommands {
+    /// Set the collection mint on the candy machine
+    Set {
         /// Path to the keypair file, uses Sol config or defaults to "~/.config/solana/id.json"
         #[clap(short, long)]
         keypair: Option<String>,
@@ -258,21 +267,28 @@ pub enum Commands {
         #[clap(long)]
         candy_machine: Option<String>,
 
-        #[clap(subcommand)]
-        command: CollectionSubcommands,
-    },
-}
-
-#[derive(Subcommand)]
-pub enum CollectionSubcommands {
-    /// Set the collection mint on the candy machine
-    Set {
         /// Address of collection mint to set the candy machine to.
         collection_mint: String,
     },
 
     /// Remove the collection from the candy machine
-    Remove,
+    Remove {
+        /// Path to the keypair file, uses Sol config or defaults to "~/.config/solana/id.json"
+        #[clap(short, long)]
+        keypair: Option<String>,
+
+        /// RPC Url
+        #[clap(short, long)]
+        rpc_url: Option<String>,
+
+        /// Path to the cache file, defaults to "cache.json"
+        #[clap(long, default_value = DEFAULT_CACHE)]
+        cache: String,
+
+        /// Address of candy machine to update.
+        #[clap(long)]
+        candy_machine: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/collections/remove.rs
+++ b/src/collections/remove.rs
@@ -33,7 +33,7 @@ pub fn process_remove_collection(args: RemoveCollectionArgs) -> Result<()> {
         None => &cache.program.candy_machine,
     };
 
-    let candy_pubkey = match Pubkey::from_str(&candy_machine_id) {
+    let candy_pubkey = match Pubkey::from_str(candy_machine_id) {
         Ok(candy_pubkey) => candy_pubkey,
         Err(_) => {
             let error = anyhow!("Failed to parse candy machine id: {}", candy_machine_id);

--- a/src/collections/remove.rs
+++ b/src/collections/remove.rs
@@ -25,12 +25,15 @@ pub fn process_remove_collection(args: RemoveCollectionArgs) -> Result<()> {
     let sugar_config = sugar_setup(args.keypair, args.rpc_url)?;
     let client = setup_client(&sugar_config)?;
     let program = client.program(CANDY_MACHINE_ID);
-    let mut cache = load_cache(&args.cache, false)?;
+    let mut cache = Cache::new();
 
     // the candy machine id specified takes precedence over the one from the cache
     let candy_machine_id = match args.candy_machine {
         Some(ref candy_machine_id) => candy_machine_id,
-        None => &cache.program.candy_machine,
+        None => {
+            cache = load_cache(&args.cache, false)?;
+            &cache.program.candy_machine
+        }
     };
 
     let candy_pubkey = match Pubkey::from_str(candy_machine_id) {

--- a/src/collections/remove.rs
+++ b/src/collections/remove.rs
@@ -25,15 +25,12 @@ pub fn process_remove_collection(args: RemoveCollectionArgs) -> Result<()> {
     let sugar_config = sugar_setup(args.keypair, args.rpc_url)?;
     let client = setup_client(&sugar_config)?;
     let program = client.program(CANDY_MACHINE_ID);
-    let cache_option: Option<Cache> = None;
+    let mut cache = load_cache(&args.cache, false)?;
 
     // the candy machine id specified takes precedence over the one from the cache
     let candy_machine_id = match args.candy_machine {
-        Some(candy_machine_id) => candy_machine_id,
-        None => {
-            let cache_option = Some(load_cache(&args.cache, false)?);
-            cache_option.unwrap().program.candy_machine
-        }
+        Some(ref candy_machine_id) => candy_machine_id,
+        None => &cache.program.candy_machine,
     };
 
     let candy_pubkey = match Pubkey::from_str(&candy_machine_id) {
@@ -80,8 +77,10 @@ pub fn process_remove_collection(args: RemoveCollectionArgs) -> Result<()> {
         &collection_metadata_info,
     )?;
 
-    if let Some(mut cache) = cache_option {
-        cache.items.remove("-1");
+    // If a candy machine id wasn't manually specified we are operating on the candy machine in the cache
+    // and so need to update the cache file.
+    if args.candy_machine.is_none() {
+        cache.items.shift_remove("-1");
         cache.program.collection_mint = String::new();
         cache.sync_file()?;
     }

--- a/src/collections/set.rs
+++ b/src/collections/set.rs
@@ -30,12 +30,15 @@ pub fn process_set_collection(args: SetCollectionArgs) -> Result<()> {
     let sugar_config = sugar_setup(args.keypair, args.rpc_url)?;
     let client = setup_client(&sugar_config)?;
     let program = client.program(CANDY_MACHINE_ID);
-    let mut cache = load_cache(&args.cache, false)?;
+    let mut cache = Cache::new();
 
-    // the candy machine id specified takes precedence over the one from the cache
+    // The candy machine id specified takes precedence over the one from the cache.
     let candy_machine_id = match args.candy_machine {
         Some(ref candy_machine_id) => candy_machine_id,
-        None => &cache.program.candy_machine,
+        None => {
+            cache = load_cache(&args.cache, false)?;
+            &cache.program.candy_machine
+        }
     };
 
     let collection_mint_pubkey = match Pubkey::from_str(&args.collection_mint) {

--- a/src/config/data.rs
+++ b/src/config/data.rs
@@ -148,7 +148,7 @@ fn discount_price_to_lamports(discount_price: Option<f64>) -> Option<u64> {
     discount_price.map(|price| (price * LAMPORTS_PER_SOL as f64) as u64)
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GatekeeperConfig {
     /// The network for the gateway token required
@@ -176,13 +176,13 @@ impl GatekeeperConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EndSettingType {
     Date,
     Amount,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EndSettings {
     #[serde(rename = "endSettingType")]
     end_setting_type: EndSettingType,
@@ -242,7 +242,7 @@ impl WhitelistMintSettings {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum WhitelistMintMode {
     BurnEveryTime,
@@ -270,7 +270,7 @@ impl FromStr for WhitelistMintMode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HiddenSettings {
     name: String,
     uri: String,
@@ -294,7 +294,7 @@ impl HiddenSettings {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum UploadMethod {
     Bundlr,

--- a/src/main.rs
+++ b/src/main.rs
@@ -265,23 +265,26 @@ async fn run() -> Result<()> {
             candy_machine,
             unminted,
         })?,
-        Commands::Collection {
-            keypair,
-            rpc_url,
-            cache,
-            candy_machine,
-            command,
-        } => match command {
-            CollectionSubcommands::Set { collection_mint } => {
-                process_set_collection(SetCollectionArgs {
-                    collection_mint,
-                    keypair,
-                    rpc_url,
-                    cache,
-                    candy_machine,
-                })?
-            }
-            CollectionSubcommands::Remove => process_remove_collection(RemoveCollectionArgs {
+        Commands::Collection { command } => match command {
+            CollectionSubcommands::Set {
+                keypair,
+                rpc_url,
+                cache,
+                candy_machine,
+                collection_mint,
+            } => process_set_collection(SetCollectionArgs {
+                collection_mint,
+                keypair,
+                rpc_url,
+                cache,
+                candy_machine,
+            })?,
+            CollectionSubcommands::Remove {
+                keypair,
+                rpc_url,
+                cache,
+                candy_machine,
+            } => process_remove_collection(RemoveCollectionArgs {
                 keypair,
                 rpc_url,
                 cache,


### PR DESCRIPTION
This PR moves all the `collection` options to the sub-commands to make usage more intuitive. It also fixes some bugs in the `set` and `remove` commands:

Previously commands were formatted like:

```bash
sugar collection --option1 --option2 set <mint_address>`
```

now they are:

```bash
sugar collection set <mint_address> --option1 --option2
```

Bugs:
* the `cache_option` is shadowed in the candy machine logic so is always `None`
* the `remove` command is messing up the order of the cache items

I'm using the `args.candy_machine` option to detect whether the cache file needs to be updated.
I'm using `shift_remove` to maintain ordering of cache file items.