### PR TITLE
refactor(validate): relax validator; simplify error handling and logging

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,11 @@
-use std::path::PathBuf;
-
+use serde::Serialize;
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
 use thiserror::Error;
+
+use crate::common::*;
 
 #[derive(Debug, Error)]
 pub enum SetupError {
@@ -27,34 +32,25 @@ pub enum CacheError {
 }
 
 #[derive(Debug, Error)]
-pub enum ReadFilesError {
-    #[error("Path errors, check log file for details.")]
-    PathErrors,
-
-    #[error("Deserialize errors, check log file for details.")]
-    DeserializeErrors,
-
-    #[error("Validate errors, check log file for details.")]
-    ValidateErrors,
-
-    #[error("File open errors, check log file for details.")]
-    FileOpenErrors,
-}
-
-#[derive(Debug, Error)]
 pub enum CustomCandyError {
     #[error("Payer key '{0}' does not equal the Candy Machine authority pubkey '{1}'")]
     AuthorityMismatch(String, String),
 }
 
-#[derive(Debug)]
-pub struct DeserializeError<'a> {
+#[derive(Debug, Serialize)]
+pub struct ValidateError<'a> {
     pub path: &'a PathBuf,
-    pub error: serde_json::Error,
+    pub error: String,
 }
 
-#[derive(Debug)]
-pub struct FileOpenError<'a> {
-    pub path: &'a PathBuf,
-    pub error: std::io::Error,
+pub fn log_errors<T: std::fmt::Debug + Serialize>(
+    error_type: &str,
+    errors: Arc<Mutex<Vec<T>>>,
+) -> Result<()> {
+    let errors = &*errors.lock().unwrap();
+    error!("{error_type}: {errors:?}");
+    let f = File::create("validate_errors.json")?;
+    serde_json::to_writer_pretty(f, &errors)?;
+
+    Ok(())
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,8 +1,9 @@
-use serde::Serialize;
 use std::{
     path::PathBuf,
     sync::{Arc, Mutex},
 };
+
+use serde::Serialize;
 use thiserror::Error;
 
 use crate::common::*;

--- a/src/validate/errors.rs
+++ b/src/validate/errors.rs
@@ -18,7 +18,7 @@ pub enum ValidateParserError {
     #[error("Url exceeds 200 chars.")]
     UrlTooLong,
 
-    #[error("Creator address: {0} is invalid.")]
+    #[error("Creator address: '{0}' is invalid.")]
     InvalidCreatorAddress(String),
 
     #[error("Creators' share does not equal 100%.")]

--- a/src/validate/errors.rs
+++ b/src/validate/errors.rs
@@ -1,7 +1,8 @@
+use serde::Serialize;
 use thiserror::Error;
 
-#[derive(Debug, Error)]
-pub enum ValidateError {
+#[derive(Debug, Error, Serialize)]
+pub enum ValidateParserError {
     #[error("Missing or empty assets directory")]
     MissingOrEmptyAssetsDirectory,
 

--- a/src/validate/errors.rs
+++ b/src/validate/errors.rs
@@ -21,11 +21,11 @@ pub enum ValidateParserError {
     #[error("Creator address: '{0}' is invalid.")]
     InvalidCreatorAddress(String),
 
-    #[error("Creators' share does not equal 100%.")]
+    #[error("Combined creators' share does not equal 100%.")]
     InvalidCreatorShare,
 
-    #[error("Seller fee basis points must be between 0 and 10,000.")]
-    InvalidSellerFeeBasisPoints,
+    #[error("Seller fee basis points value '{0}' is invalid: must be between 0 and 10,000.")]
+    InvalidSellerFeeBasisPoints(u16),
 
     #[error("Missing animation url field")]
     MissingAnimationUrl,

--- a/src/validate/format.rs
+++ b/src/validate/format.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::validate::{errors, parser};
 
+use super::ValidateParserError;
+
 #[derive(Debug, Clone, Deserialize, Default, Serialize)]
 pub struct Metadata {
     pub name: String,
@@ -13,12 +15,11 @@ pub struct Metadata {
     pub animation_url: Option<String>,
     pub external_url: Option<String>,
     pub attributes: Vec<Attribute>,
-    pub collection: Option<Collection>,
     pub properties: Property,
 }
 
 impl Metadata {
-    pub fn validate(self) -> Result<()> {
+    pub fn validate(self) -> Result<(), ValidateParserError> {
         parser::check_name(&self.name)?;
         parser::check_symbol(&self.symbol)?;
         parser::check_url(&self.image)?;
@@ -27,19 +28,15 @@ impl Metadata {
         Ok(())
     }
 
-    pub fn validate_strict(self) -> Result<()> {
+    pub fn validate_strict(self) -> Result<(), ValidateParserError> {
         if self.animation_url.is_none() {
-            return Err(errors::ValidateError::MissingAnimationUrl.into());
+            return Err(errors::ValidateParserError::MissingAnimationUrl);
         } else {
             parser::check_url(&self.animation_url.unwrap())?;
         }
 
-        if self.collection.is_none() {
-            return Err(errors::ValidateError::MissingCollection.into());
-        }
-
         if self.external_url.is_none() {
-            return Err(errors::ValidateError::MissingExternalUrl.into());
+            return Err(errors::ValidateParserError::MissingExternalUrl);
         } else {
             parser::check_url(&self.external_url.unwrap())?;
         }
@@ -54,15 +51,8 @@ impl Metadata {
 }
 
 #[derive(Debug, Clone, Deserialize, Default, Serialize)]
-pub struct Collection {
-    pub name: String,
-    pub family: String,
-}
-
-#[derive(Debug, Clone, Deserialize, Default, Serialize)]
 pub struct Property {
     pub files: Vec<FileAttr>,
-    pub category: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Default, Serialize)]

--- a/src/validate/format.rs
+++ b/src/validate/format.rs
@@ -19,32 +19,31 @@ pub struct Metadata {
 }
 
 impl Metadata {
-    pub fn validate(self) -> Result<(), ValidateParserError> {
+    pub fn validate(&self) -> Result<(), ValidateParserError> {
         parser::check_name(&self.name)?;
         parser::check_symbol(&self.symbol)?;
         parser::check_url(&self.image)?;
         parser::check_seller_fee_basis_points(self.seller_fee_basis_points)?;
+        parser::check_creators_shares(&self.properties.creators)?;
+        parser::check_creators_addresses(&self.properties.creators)?;
 
         Ok(())
     }
 
-    pub fn validate_strict(self) -> Result<(), ValidateParserError> {
-        if self.animation_url.is_none() {
+    pub fn validate_strict(&self) -> Result<(), ValidateParserError> {
+        if let Some(animation_url) = &self.animation_url {
+            parser::check_url(animation_url)?;
+        } else {
             return Err(errors::ValidateParserError::MissingAnimationUrl);
-        } else {
-            parser::check_url(&self.animation_url.unwrap())?;
         }
 
-        if self.external_url.is_none() {
+        if let Some(external_url) = &self.external_url {
+            parser::check_url(external_url)?;
+        } else {
             return Err(errors::ValidateParserError::MissingExternalUrl);
-        } else {
-            parser::check_url(&self.external_url.unwrap())?;
         }
 
-        parser::check_name(&self.name)?;
-        parser::check_symbol(&self.symbol)?;
-        parser::check_url(&self.image)?;
-        parser::check_seller_fee_basis_points(self.seller_fee_basis_points)?;
+        Self::validate(self)?;
 
         Ok(())
     }
@@ -53,6 +52,13 @@ impl Metadata {
 #[derive(Debug, Clone, Deserialize, Default, Serialize)]
 pub struct Property {
     pub files: Vec<FileAttr>,
+    pub creators: Vec<Creator>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default, Serialize)]
+pub struct Creator {
+    pub address: String,
+    pub share: u16,
 }
 
 #[derive(Debug, Clone, Deserialize, Default, Serialize)]

--- a/src/validate/format.rs
+++ b/src/validate/format.rs
@@ -1,9 +1,8 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::validate::{errors, parser};
-
 use super::ValidateParserError;
+use crate::validate::{errors, parser};
 
 #[derive(Debug, Clone, Deserialize, Default, Serialize)]
 pub struct Metadata {

--- a/src/validate/parser.rs
+++ b/src/validate/parser.rs
@@ -1,31 +1,33 @@
 pub use mpl_token_metadata::state::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH};
 
-use crate::validate::errors::ValidateError;
+use crate::validate::errors::ValidateParserError;
 
-pub fn check_name(name: &str) -> Result<(), ValidateError> {
+pub fn check_name(name: &str) -> Result<(), ValidateParserError> {
     if name.len() > MAX_NAME_LENGTH {
-        return Err(ValidateError::NameTooLong);
+        return Err(ValidateParserError::NameTooLong);
     }
     Ok(())
 }
 
-pub fn check_symbol(symbol: &str) -> Result<(), ValidateError> {
+pub fn check_symbol(symbol: &str) -> Result<(), ValidateParserError> {
     if symbol.len() > MAX_SYMBOL_LENGTH {
-        return Err(ValidateError::SymbolTooLong);
+        return Err(ValidateParserError::SymbolTooLong);
     }
     Ok(())
 }
 
-pub fn check_url(url: &str) -> Result<(), ValidateError> {
+pub fn check_url(url: &str) -> Result<(), ValidateParserError> {
     if url.len() > MAX_URI_LENGTH {
-        return Err(ValidateError::UrlTooLong);
+        return Err(ValidateParserError::UrlTooLong);
     }
     Ok(())
 }
 
-pub fn check_seller_fee_basis_points(seller_fee_basis_points: u16) -> Result<(), ValidateError> {
+pub fn check_seller_fee_basis_points(
+    seller_fee_basis_points: u16,
+) -> Result<(), ValidateParserError> {
     if seller_fee_basis_points > 10000 {
-        return Err(ValidateError::InvalidCreatorShare);
+        return Err(ValidateParserError::InvalidCreatorShare);
     }
     Ok(())
 }

--- a/src/validate/parser.rs
+++ b/src/validate/parser.rs
@@ -30,7 +30,9 @@ pub fn check_seller_fee_basis_points(
     seller_fee_basis_points: u16,
 ) -> Result<(), ValidateParserError> {
     if seller_fee_basis_points > 10000 {
-        return Err(ValidateParserError::InvalidSellerFeeBasisPoints);
+        return Err(ValidateParserError::InvalidSellerFeeBasisPoints(
+            seller_fee_basis_points,
+        ));
     }
     Ok(())
 }

--- a/src/validate/parser.rs
+++ b/src/validate/parser.rs
@@ -1,6 +1,9 @@
+use std::str::FromStr;
+
+use anchor_lang::prelude::Pubkey;
 pub use mpl_token_metadata::state::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH};
 
-use crate::validate::errors::ValidateParserError;
+use crate::validate::{errors::ValidateParserError, Creator};
 
 pub fn check_name(name: &str) -> Result<(), ValidateParserError> {
     if name.len() > MAX_NAME_LENGTH {
@@ -27,7 +30,28 @@ pub fn check_seller_fee_basis_points(
     seller_fee_basis_points: u16,
 ) -> Result<(), ValidateParserError> {
     if seller_fee_basis_points > 10000 {
+        return Err(ValidateParserError::InvalidSellerFeeBasisPoints);
+    }
+    Ok(())
+}
+
+pub fn check_creators_shares(creators: &Vec<Creator>) -> Result<(), ValidateParserError> {
+    let mut shares = 0;
+    for creator in creators {
+        shares += creator.share;
+    }
+
+    if shares != 100 {
         return Err(ValidateParserError::InvalidCreatorShare);
     }
+    Ok(())
+}
+
+pub fn check_creators_addresses(creators: &Vec<Creator>) -> Result<(), ValidateParserError> {
+    for creator in creators {
+        Pubkey::from_str(&creator.address)
+            .map_err(|_| ValidateParserError::InvalidCreatorAddress(creator.address.clone()))?;
+    }
+
     Ok(())
 }


### PR DESCRIPTION
Fixes #246 by relaxing the validator to only check for fields specified in our docs.

Refactors `validate` error handling to have a single error vector and write all errors to a `validate_errors.json` file to make it easier for the user to see them (rather than having to dig in the sugar.log file). 

New output error message:
![Selection_882](https://user-images.githubusercontent.com/1684605/178840146-3225878e-504c-48b2-84c9-920ed5156b95.png)

Example `validate_errors.json` file:
![Selection_885](https://user-images.githubusercontent.com/1684605/178842824-2f83a5f4-3b34-423b-9f6e-cc52a83f2a14.png)


