### PR TITLE
fix: improve error for invalid wl token

### DIFF
--- a/src/mint/process.rs
+++ b/src/mint/process.rs
@@ -300,7 +300,8 @@ pub fn mint(
                 Err(err) => {
                     error!("Invalid whitelist token account: {}", err);
                     return Err(anyhow!(
-                        "Uninitialized whitelist token account: {whitelist_token_account}"
+                        "Uninitialized whitelist token account: {whitelist_token_account}.
+                         Check that you provided a valid SPL token mint for the whitelist."
                     ));
                 }
             }

--- a/src/mint/process.rs
+++ b/src/mint/process.rs
@@ -297,7 +297,12 @@ pub fn mint(
                         }
                     }
                 }
-                Err(err) => return Err(anyhow!(err)),
+                Err(err) => {
+                    error!("Invalid whitelist token account: {}", err);
+                    return Err(anyhow!(
+                        "Uninitialized whitelist token account: {whitelist_token_account}"
+                    ));
+                }
             }
 
             if !token_found {


### PR DESCRIPTION
Multiple users have run into issues with using invalid whitelist token accounts. Currently the error returned is:

```
AccountNotFound: pubkey=<associated_token_address>
```

This PR provides a more meaningful error:

```
                        "Uninitialized whitelist token account: {whitelist_token_account}.
                         Check that you provided a valid SPL token mint for the whitelist."
```

This should be more clear to the user what the issue is and allow them to fix it by checking that they have provided a valid mint address for their whitelist.