### PR TITLE
fix: mint to keypair instead of cm wallet

### DIFF
--- a/src/hash/process.rs
+++ b/src/hash/process.rs
@@ -68,7 +68,7 @@ pub fn process_hash(args: HashArgs) -> Result<()> {
         );
         std::process::exit(0);
     } else {
-        return Err(anyhow!("No hidden settings found in config file."));
+        Err(anyhow!("No hidden settings found in config file."))
     }
 }
 

--- a/src/mint/process.rs
+++ b/src/mint/process.rs
@@ -91,7 +91,7 @@ pub async fn process_mint(args: MintArgs) -> Result<()> {
     let receiver_pubkey = match args.receiver {
         Some(receiver_id) => Pubkey::from_str(&receiver_id)
             .map_err(|_| anyhow!("Failed to parse receiver pubkey: {}", receiver_id))?,
-        None => candy_machine_state.wallet,
+        None => sugar_config.keypair.pubkey(),
     };
     println!("\nMinting to {}", &receiver_pubkey);
 


### PR DESCRIPTION
The `mint` command should mint to the keypair calling the command by default, instead of the wallet currently configured in the candy machine wallet.