### PR TITLE
ci: cargo-husky and pre-commit git hook

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# -e : exit immediately if a command exits with a non-zero status
+# -u : treat unset variables as an error
+set -eu
+
+if ! cargo +nightly fmt -- --check
+then
+    echo "There are some code style issues."
+    echo "Run `cargo +nightly fmt` first."
+    exit 1
+fi
+
+if ! cargo clippy --all-targets -- -D warnings
+then
+    echo "There are some clippy issues."
+    exit 1
+fi
+
+if ! cargo test
+then
+    echo "There are failing tests."
+    exit 1
+fi
+
+exit 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-husky"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4515,6 +4521,7 @@ dependencies = [
  "borsh",
  "bs58 0.4.0",
  "bundlr-sdk",
+ "cargo-husky",
  "chrono",
  "clap 3.2.16",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,8 @@ tracing = { version = "0.1.35", features = ["log"] }
 tracing-bunyan-formatter = "0.3.3"
 tracing-subscriber = { version = "0.3.14", features = ["registry", "env-filter"] }
 url = "2.2.2"
+
+[dev-dependencies.cargo-husky]
+version = "1"
+default-features = false
+features = ["precommit-hook", "user-hooks"]


### PR DESCRIPTION
This PR sets up a custom git hook that will be moved into the .git/hooks directory the first time a clean run of `cargo test` is done. Thereafter, it runs `cargo +nightly fmt`, `cargo clippy` and `cargo test` as a pre-commit hook for git. 