### PR TITLE
Feat: Date Parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,6 +1054,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
+name = "dateparser"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dcee48ba66b79ba92dab399f218228f98c5d601ca85127fbc1ad60caf237d8"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "der"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4520,6 +4532,7 @@ dependencies = [
  "console",
  "ctrlc",
  "data-encoding",
+ "dateparser",
  "dialoguer 0.10.2",
  "dirs",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ clap = { version = "3.2.8", features = ["derive", "cargo"] }
 console = "0.15.0"
 ctrlc = "3.2.2"
 data-encoding = "2.3.2"
+dateparser = "0.1.6"
 dialoguer = "0.10.1"
 dirs = "4.0.0"
 futures = "0.3.21"

--- a/src/config/data.rs
+++ b/src/config/data.rs
@@ -7,7 +7,7 @@ use anchor_client::solana_sdk::{
     native_token::LAMPORTS_PER_SOL, pubkey::Pubkey, signature::Keypair,
 };
 pub use anyhow::{anyhow, Result};
-use chrono::DateTime;
+use dateparser::DateTimeUtc;
 use mpl_candy_machine::{
     Creator as CandyCreator, EndSettingType as CandyEndSettingType,
     EndSettings as CandyEndSettings, GatekeeperConfig as CandyGatekeeperConfig,
@@ -98,22 +98,14 @@ where
 }
 
 pub fn parse_string_as_date(go_live_date: &str) -> Result<String> {
-    let date = DateTime::parse_from_str(go_live_date, "%Y-%m-%d %H:%M:%S %z")?;
-    Ok(date.to_rfc2822())
+    let date = dateparser::parse(&go_live_date)?;
+    Ok(date.to_rfc3339())
 }
 
 pub fn go_live_date_as_timestamp(go_live_date: &Option<String>) -> Result<Option<i64>> {
     if let Some(go_live_date) = go_live_date {
-        let format = if let Ok(date) = chrono::DateTime::parse_from_rfc2822(go_live_date) {
-            date.timestamp()
-        } else if let Ok(date) = chrono::DateTime::parse_from_rfc3339(go_live_date) {
-            date.timestamp()
-        } else if let Ok(timestamp) = go_live_date.parse::<i64>() {
-            timestamp
-        } else {
-            return Err(anyhow!("Invalid date format. Format must be: RFC2822(Fri, 14 Jul 2022 02:40:00 -0400), RFC3339(2022-02-25T13:00:00Z), or UNIX timestamp."));
-        };
-        Ok(Some(format))
+        let date = dateparser::parse(go_live_date)?;
+        Ok(Some(date.timestamp()))
     } else {
         Ok(None)
     }
@@ -186,23 +178,56 @@ pub enum EndSettingType {
 pub struct EndSettings {
     #[serde(rename = "endSettingType")]
     end_setting_type: EndSettingType,
-    number: u64,
+    number: Option<u64>,
+    date: Option<String>,
 }
 
 impl EndSettings {
-    pub fn new(end_setting_type: EndSettingType, number: u64) -> EndSettings {
+    pub fn new(
+        end_setting_type: EndSettingType,
+        number: Option<u64>,
+        date: Option<String>,
+    ) -> EndSettings {
         EndSettings {
             end_setting_type,
             number,
+            date,
         }
     }
-    pub fn to_candy_format(&self) -> CandyEndSettings {
-        CandyEndSettings {
-            end_setting_type: match self.end_setting_type {
-                EndSettingType::Date => CandyEndSettingType::Date,
-                EndSettingType::Amount => CandyEndSettingType::Amount,
-            },
-            number: self.number,
+    pub fn to_candy_format(&self) -> Result<CandyEndSettings> {
+        match self.end_setting_type {
+            // For amount, we just make sure the Option is Some and use that value.
+            EndSettingType::Amount => {
+                let number = self
+                    .number
+                    .ok_or_else(|| anyhow!("No number set for EndSetting Amount"))?;
+                let end_setting_type = CandyEndSettingType::Amount;
+
+                Ok(CandyEndSettings {
+                    end_setting_type,
+                    number,
+                })
+            }
+            // For date, we need to make sure the Option is Some and parse the date to a Unix timestamp.
+            EndSettingType::Date => {
+                // The onchain data struct uses a u64 for the timestamp, so we use try_from to safely convert.
+                // Timestamps older than Jan 1, 1970 are not supported.
+                let timestamp = self
+                    .date
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("No date set for Endsetting Date"))?
+                    .parse::<DateTimeUtc>()?
+                    .0
+                    .timestamp();
+                let number: u64 = u64::try_from(timestamp)
+                    .map_err(|_| anyhow!("Error: the date is prior to Jan 1, 1970."))?;
+                let end_setting_type = CandyEndSettingType::Date;
+
+                Ok(CandyEndSettings {
+                    end_setting_type,
+                    number,
+                })
+            }
         }
     }
 }

--- a/src/config/data.rs
+++ b/src/config/data.rs
@@ -7,6 +7,7 @@ use anchor_client::solana_sdk::{
     native_token::LAMPORTS_PER_SOL, pubkey::Pubkey, signature::Keypair,
 };
 pub use anyhow::{anyhow, Result};
+use chrono::prelude::*;
 use dateparser::DateTimeUtc;
 use mpl_candy_machine::{
     Creator as CandyCreator, EndSettingType as CandyEndSettingType,
@@ -98,7 +99,8 @@ where
 }
 
 pub fn parse_string_as_date(go_live_date: &str) -> Result<String> {
-    let date = dateparser::parse(go_live_date)?;
+    let date = dateparser::parse_with(go_live_date, &Local, NaiveTime::from_hms(0, 0, 0))?;
+
     Ok(date.to_rfc3339())
 }
 

--- a/src/config/data.rs
+++ b/src/config/data.rs
@@ -98,7 +98,7 @@ where
 }
 
 pub fn parse_string_as_date(go_live_date: &str) -> Result<String> {
-    let date = dateparser::parse(&go_live_date)?;
+    let date = dateparser::parse(go_live_date)?;
     Ok(date.to_rfc3339())
 }
 

--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -245,7 +245,7 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
 
     let null_or_none = |input: &str| -> bool { input == "none" || input == "null" };
     let date= Input::with_theme(&theme)
-    .with_prompt("What is your go live date? Many common formats are supported. If unsure, try YYYY-MM-DD HH:MM:SS [+/-]UTC-OFFSET  or type 'now' for \
+    .with_prompt("What is your go live date? Many common formats are supported. If unsure, try YYYY-MM-DD HH:MM:SS [+/-]UTC-OFFSET or type 'now' for \
      current time. For example 2022-05-02 18:00:00 +0000 for May 2, 2022 18:00:00 UTC.")
      .validate_with(|input: &String| {
         let trimmed = input.trim().to_lowercase();

--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -8,6 +8,7 @@ use std::{
 
 use anchor_lang::prelude::Pubkey;
 use anyhow::{anyhow, Result};
+use chrono::prelude::*;
 use console::style;
 use dialoguer::{Confirm, Input, MultiSelect, Select};
 use url::Url;
@@ -244,7 +245,7 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
 
     let null_or_none = |input: &str| -> bool { input == "none" || input == "null" };
     let date= Input::with_theme(&theme)
-    .with_prompt("What is your go live date? Enter it this format, YYYY-MM-DD HH:MM:SS [+/-]UTC-OFFSET or type 'now' for \
+    .with_prompt("What is your go live date? Many common formats are supported. If unsure, try YYYY-MM-DD HH:MM:SS [+/-]UTC-OFFSET  or type 'now' for \
      current time. For example 2022-05-02 18:00:00 +0000 for May 2, 2022 18:00:00 UTC.")
      .validate_with(|input: &String| {
         let trimmed = input.trim().to_lowercase();
@@ -265,7 +266,7 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
     } else if null_or_none(&trimmed) {
         None
     } else {
-        let date = dateparser::parse(&date)?;
+        let date = dateparser::parse_with(&date, &Local, NaiveTime::from_hms(0, 0, 0))?;
         Some(date.to_rfc3339())
     };
 
@@ -509,7 +510,7 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
             EndSettingType::Date => {
                 println!("Date setting detected");
                 let date = Input::with_theme(&theme)
-                    .with_prompt("What is the date to stop the mint? Most common formats are supported. If unsure, try YYYY-MM-DD HH:MM:SS [+/-]UTC-OFFSET. \
+                    .with_prompt("What is the date to stop the mint? Many common formats are supported. If unsure, try YYYY-MM-DD HH:MM:SS [+/-]UTC-OFFSET. \
                     For example 2022-05-02 18:00:00 +0000 for May 2, 2022 18:00:00 UTC.")
                     .validate_with(date_validator)
                     .interact()

--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -8,7 +8,6 @@ use std::{
 
 use anchor_lang::prelude::Pubkey;
 use anyhow::{anyhow, Result};
-use chrono::DateTime;
 use console::style;
 use dialoguer::{Confirm, Input, MultiSelect, Select};
 use url::Url;
@@ -31,9 +30,6 @@ const DEFAULT_METADATA: &str = "0.json";
 
 /// Default value to represent an invalid seller fee basis points.
 const INVALID_SELLER_FEE: u16 = u16::MAX;
-
-/// Date mask for formatting input.
-const DATE_MASK: &str = "%Y-%m-%d %H:%M:%S %z";
 
 pub struct CreateConfigArgs {
     pub keypair: Option<String>,
@@ -265,12 +261,12 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
 
     config_data.go_live_date = if trimmed == "now" {
         let current_time = chrono::Utc::now();
-        Some(current_time.format("%d %b %Y %H:%M:%S %z").to_string())
+        Some(current_time.to_rfc3339())
     } else if null_or_none(&trimmed) {
         None
     } else {
-        let date = DateTime::parse_from_str(&date, DATE_MASK)?;
-        Some(date.format("%d %b %Y %H:%M:%S %z").to_string())
+        let date = dateparser::parse(&date)?;
+        Some(date.to_rfc3339())
     };
 
     // creators
@@ -478,7 +474,7 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
     // end settings
 
     config_data.end_settings = if choices.contains(&END_SETTINGS_INDEX) {
-        let end_settings_options = vec!["Date", "Amount"];
+        let end_settings_options = vec!["Amount", "Date"];
         let end_setting_type = match Select::with_theme(&theme)
             .with_prompt("What end settings type do you want to use?")
             .items(&end_settings_options)
@@ -486,13 +482,14 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
             .interact()
             .unwrap()
         {
-            0 => EndSettingType::Date,
-            1 => EndSettingType::Amount,
-            _ => EndSettingType::Date,
+            0 => EndSettingType::Amount,
+            1 => EndSettingType::Date,
+            _ => panic!("Invalid end setting type"),
         };
 
-        let number = match end_setting_type {
-            EndSettingType::Amount => Input::with_theme(&theme)
+        match end_setting_type {
+            EndSettingType::Amount => {
+                let number = Input::with_theme(&theme)
                 .with_prompt("What is the amount to stop the mint?")
                 .validate_with(number_validator)
                 .validate_with(|num: &String| {
@@ -505,20 +502,33 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
                 .interact()
                 .unwrap()
                 .parse::<u64>()
-                .expect("Failed to parse number into u64 that should have already been validated."),
+                .expect("Failed to parse number into u64 that should have already been validated.");
+
+                Some(EndSettings::new(end_setting_type, Some(number), None))
+            }
             EndSettingType::Date => {
+                println!("Date setting detected");
                 let date = Input::with_theme(&theme)
-                    .with_prompt("What is the date to stop the mint? Enter it this format, YYYY-MM-DD HH:MM:SS [+/-]UTC-OFFSET. \
+                    .with_prompt("What is the date to stop the mint? Most common formats are supported. If unsure, try YYYY-MM-DD HH:MM:SS [+/-]UTC-OFFSET. \
                     For example 2022-05-02 18:00:00 +0000 for May 2, 2022 18:00:00 UTC.")
                     .validate_with(date_validator)
                     .interact()
                     .unwrap();
-                    let date_time = DateTime::parse_from_str(&date, DATE_MASK)?;
-                    date_time.timestamp() as u64
-            }
-        };
 
-        Some(EndSettings::new(end_setting_type, number))
+                println!("date:{}:date", date);
+
+                // Convert to ISO 8601 for consistency, before storing in config.
+                let formatted_date = parse_string_as_date(&date)?;
+
+                println!("formatted_date: {}", formatted_date);
+
+                Some(EndSettings::new(
+                    end_setting_type,
+                    None,
+                    Some(formatted_date),
+                ))
+            }
+        }
     } else {
         None
     };

--- a/src/deploy/initialize.rs
+++ b/src/deploy/initialize.rs
@@ -24,7 +24,11 @@ pub fn create_candy_machine_data(
 ) -> Result<CandyMachineData> {
     let go_live_date: Option<i64> = go_live_date_as_timestamp(&config.go_live_date)?;
 
-    let end_settings = config.end_settings.as_ref().map(|s| s.to_candy_format());
+    let end_settings = if let Some(end_settings) = &config.end_settings {
+        Some(end_settings.to_candy_format()?)
+    } else {
+        None
+    };
 
     let whitelist_mint_settings = config
         .whitelist_mint_settings

--- a/src/update/process.rs
+++ b/src/update/process.rs
@@ -189,7 +189,11 @@ fn create_candy_machine_data(
     info!("{:?}", config.go_live_date);
     let go_live_date: Option<i64> = go_live_date_as_timestamp(&config.go_live_date)?;
 
-    let end_settings = config.end_settings.as_ref().map(|s| s.to_candy_format());
+    let end_settings = if let Some(end_settings) = &config.end_settings {
+        Some(end_settings.to_candy_format()?)
+    } else {
+        None
+    };
 
     let whitelist_mint_settings = config
         .whitelist_mint_settings


### PR DESCRIPTION
Addresses #315. 

Adds the `dateparser` library to accept a wide range of date inputs and then converts and stores them as ISO8601 in the UTC timezone.

Changes the EndSetting struct local to Sugar to have both a `Number` and `Date` field to allow storing the date as a string in the config file for consistency. 

<img width="1382" alt="Screen Shot 2022-08-12 at 3 19 22 PM" src="https://user-images.githubusercontent.com/1684605/184458029-32e31815-8076-46c3-a762-68c356777a28.png">
<img width="1375" alt="Screen Shot 2022-08-12 at 3 04 20 PM" src="https://user-images.githubusercontent.com/1684605/184458054-ac63d1cb-9b4d-4779-afbb-58f9f3ef3d8a.png">
<img width="1377" alt="Screen Shot 2022-08-12 at 2 59 32 PM" src="https://user-images.githubusercontent.com/1684605/184458102-1a00df5f-1112-40e9-9cd5-d39b7a442d4e.png">

