### PR TITLE
chore: bump token-metadata and candy-machine versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2289,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-candy-machine"
-version = "4.0.2"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc08b936f755828f16fc7743c8356a76e7092270e65eb5ee54464eec51bbc12"
+checksum = "2feb2837b75c59a4476820ca2b96e157727a023b73a48315c3b9595907ab8306"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -2305,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-token-metadata"
-version = "1.2.10"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741990cd07cb31d009a345806f30ace8eab99c063cd9440eba8d3df7be2a6988"
+checksum = "029a329d7a89f7a3caf0b91bec307531f4b6c9cca34aa775454845fbbd05ac57"
 dependencies = [
  "arrayref",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ indexmap = { version = "1.9.1", features = ["serde"] }
 indicatif = { version = "0.16.2", features = ["rayon"] }
 ini = "1.3.0"
 lazy_static = "1.4.0"
-mpl-candy-machine = { version = "4.0.1", features = ["no-entrypoint"] }
-mpl-token-metadata = "=1.2.10"
+mpl-candy-machine = { version = "4.1.0", features = ["no-entrypoint"] }
+mpl-token-metadata = "1.3.4"
 num_cpus = "1.13.1"
 phf = { version = "0.10", features = ["macros"] }
 rand = "0.8.5"

--- a/src/pdas.rs
+++ b/src/pdas.rs
@@ -2,9 +2,8 @@ use anchor_client::{solana_sdk::pubkey::Pubkey, ClientError, Program};
 use anyhow::{anyhow, Result};
 use mpl_candy_machine::CollectionPDA;
 use mpl_token_metadata::{
-    deser::meta_deser,
     pda::{find_master_edition_account, find_metadata_account},
-    state::{Key, MasterEditionV2, Metadata, MAX_MASTER_EDITION_LEN},
+    state::{Key, MasterEditionV2, Metadata, TokenMetadataAccount, MAX_MASTER_EDITION_LEN},
     utils::try_from_slice_checked,
 };
 
@@ -26,7 +25,7 @@ pub fn get_metadata_pda(mint: &Pubkey, program: &Program) -> Result<PdaInfo<Meta
             &metadata_pubkey.to_string()
         )
     })?;
-    let metadata = meta_deser(&mut metadata_account.data.as_slice());
+    let metadata = Metadata::safe_deserialize(metadata_account.data.as_slice());
     metadata.map(|m| (metadata_pubkey, m)).map_err(|_| {
         anyhow!(
             "Failed to deserialize metadata account: {}",


### PR DESCRIPTION
To support sized collections we need `mpl-token-metadata` v1.3.4 which requires the latest version of `mpl-candy-machine`.