### PR TITLE
feat: add profile and directory options for aws s3

### DIFF
--- a/src/config/data.rs
+++ b/src/config/data.rs
@@ -68,8 +68,7 @@ pub struct ConfigData {
 
     pub seller_fee_basis_points: u16,
 
-    #[serde(serialize_with = "to_option_string")]
-    pub aws_s3_bucket: Option<String>,
+    pub aws_config: Option<AwsConfig>,
 
     #[serde(serialize_with = "to_option_string")]
     pub nft_storage_auth_token: Option<String>,
@@ -362,6 +361,23 @@ impl ToString for Cluster {
             Cluster::Devnet => "devnet".to_string(),
             Cluster::Mainnet => "mainnet".to_string(),
             Cluster::Unknown => "unknown".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AwsConfig {
+    pub bucket: String,
+    pub profile: String,
+    pub directory: String,
+}
+
+impl AwsConfig {
+    pub fn new(bucket: String, profile: String, directory: String) -> AwsConfig {
+        AwsConfig {
+            bucket,
+            profile,
+            directory,
         }
     }
 }

--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -16,8 +16,8 @@ use url::Url;
 use crate::{
     candy_machine::CANDY_MACHINE_ID,
     config::{
-        parse_string_as_date, ConfigData, Creator, EndSettingType, EndSettings, GatekeeperConfig,
-        HiddenSettings, UploadMethod, WhitelistMintMode, WhitelistMintSettings,
+        parse_string_as_date, AwsConfig, ConfigData, Creator, EndSettingType, EndSettings,
+        GatekeeperConfig, HiddenSettings, UploadMethod, WhitelistMintMode, WhitelistMintSettings,
     },
     constants::*,
     setup::{setup_client, sugar_setup},
@@ -572,12 +572,24 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
     };
 
     if config_data.upload_method == UploadMethod::AWS {
-        config_data.aws_s3_bucket = Some(
-            Input::with_theme(&theme)
-                .with_prompt("What is the AWS S3 bucket name?")
-                .interact()
-                .unwrap(),
-        );
+        let bucket: String = Input::with_theme(&theme)
+            .with_prompt("What is the AWS S3 bucket name?")
+            .interact()
+            .unwrap();
+
+        let profile = Input::with_theme(&theme)
+            .with_prompt("What is the AWS profile name?")
+            .default(String::from("default"))
+            .interact()
+            .unwrap();
+
+        let directory = Input::with_theme(&theme)
+            .with_prompt("What is the directory to upload to? Leave blank to store files at the bucket root dir.")
+            .default(String::from(""))
+            .interact()
+            .unwrap();
+
+        config_data.aws_config = Some(AwsConfig::new(bucket, profile, directory));
     }
 
     if config_data.upload_method == UploadMethod::NftStorage {


### PR DESCRIPTION
Addresses #322 and #307.

Changes the AWS config option from a single value to a struct:

```Rust
pub struct AwsConfig {
    pub bucket: String,
    pub profile: String,
    pub directory: String,
}
```

This allows the user to set a AWS credentials profile other than `default` to give them more flexibility. In addition, it allows specifying an optional folder name to store the assets in the S3 bucket. If no folder is provided they will be stored at the root level. This lets users store multiple collections in a single bucket.

![Selection_934](https://user-images.githubusercontent.com/1684605/184995582-5389d384-f257-49b0-a1db-f1b5a0690998.png)

Finally, this changes the file names to use the standard asset pair file names `0.json, 0.png, 1.json, 1.png` etc. to make it easier to figure out what file is what.

![Selection_935](https://user-images.githubusercontent.com/1684605/184997757-631a490d-5c80-443a-b60a-339e7cd4ca8d.png)

