### PR TITLE
refactor(bundlr): add file type to end of image and animation URLs

### DIFF
--- a/src/upload/methods/bundlr.rs
+++ b/src/upload/methods/bundlr.rs
@@ -197,7 +197,13 @@ impl BundlrMethod {
             .as_str()
             .expect("Failed to get an id from bundlr transaction.");
 
-        let link = format!("https://arweave.net/{}", id);
+        let link = match asset_info.data_type {
+            DataType::Image => format!("https://arweave.net/{id}?ext={}", asset_info.content_type),
+            DataType::Metadata => format!("https://arweave.net/{}", id),
+            DataType::Animation => {
+                format!("https://arweave.net/{id}?ext={}", asset_info.content_type)
+            }
+        };
 
         Ok((asset_info.asset_id, link))
     }

--- a/src/upload/methods/bundlr.rs
+++ b/src/upload/methods/bundlr.rs
@@ -205,11 +205,8 @@ impl BundlrMethod {
             .ok_or_else(|| anyhow!("Failed context type to get extension"))?;
 
         let link = match asset_info.data_type {
-            DataType::Image => format!("https://arweave.net/{id}?ext={ext}"),
-            DataType::Metadata => format!("https://arweave.net/{}", id),
-            DataType::Animation => {
-                format!("https://arweave.net/{id}?ext={ext}")
-            }
+            DataType::Image | DataType::Animation => format!("https://arweave.net/{id}?ext={ext}"),
+            DataType::Metadata => format!("https://arweave.net/{id}"),
         };
 
         Ok((asset_info.asset_id, link))

--- a/src/upload/methods/bundlr.rs
+++ b/src/upload/methods/bundlr.rs
@@ -197,11 +197,18 @@ impl BundlrMethod {
             .as_str()
             .expect("Failed to get an id from bundlr transaction.");
 
+        // Get extension for the asset type.
+        let ext = asset_info
+            .content_type
+            .split('/')
+            .nth(1)
+            .ok_or_else(|| anyhow!("Failed context type to get extension"))?;
+
         let link = match asset_info.data_type {
-            DataType::Image => format!("https://arweave.net/{id}?ext={}", asset_info.content_type),
+            DataType::Image => format!("https://arweave.net/{id}?ext={ext}"),
             DataType::Metadata => format!("https://arweave.net/{}", id),
             DataType::Animation => {
-                format!("https://arweave.net/{id}?ext={}", asset_info.content_type)
+                format!("https://arweave.net/{id}?ext={ext}")
             }
         };
 

--- a/src/upload/uploader.rs
+++ b/src/upload/uploader.rs
@@ -42,7 +42,7 @@ pub struct AssetInfo {
     pub asset_id: String,
     /// Name (file name) of the asset.
     pub name: String,
-    /// Content of the asset - either a file path of the string representation fo the content.
+    /// Content of the asset - either a file path or the string representation of the content.
     pub content: String,
     /// Type of the asset.
     pub data_type: DataType,


### PR DESCRIPTION
Images and animation URLs will now look like:

```
https://arweave.net/5UnllZT23t5WTqd61Ho4_-J2GxZihEBSdFkZD9d8KI0?ext=png
```

Fixes #303.