### PR TITLE
fix(reveal): skip collection item during reveal

### DIFF
--- a/src/reveal/process.rs
+++ b/src/reveal/process.rs
@@ -177,6 +177,7 @@ pub async fn process_reveal(args: RevealArgs) -> Result<()> {
     let nft_lookup: HashMap<String, &CacheItem> = cache
         .items
         .iter()
+        .filter(|(k, _)| *k != "-1") // skip collection index
         .map(|(k, item)| (increment_key(k), item))
         .collect();
 


### PR DESCRIPTION
The reveal process was trying to update the collection item and panicking because the index `-1` was outside the u32 bounds. This PR skips the collection index during updates since the collection NFT is not part of the normal reveal process. 

Fixes #328.