### PR TITLE
fix: enable CLI testing with AWS upload option

### DIFF
--- a/script/sugar-cli-test.sh
+++ b/script/sugar-cli-test.sh
@@ -261,6 +261,24 @@ if [ -z ${AWS_BUCKET+x} ]; then
     fi
 fi
 
+if [ -z ${AWS_PROFILE+x} ]; then
+    AWS_PROFILE="null"
+
+    if [ "$STORAGE" = "aws" ]; then
+        echo -n $(CYN "AWS profile name: ")
+        read AWS_PROFILE
+    fi
+fi
+
+if [ -z ${AWS_DIRECTORY+x} ]; then
+    AWS_DIRECTORY="null"
+
+    if [ "$STORAGE" = "aws" ]; then
+        echo -n $(CYN "AWS directory name: ")
+        read AWS_DIRECTORY
+    fi
+fi
+
 if [ -z ${NFT_STORAGE_TOKEN+x} ]; then
     NFT_STORAGE_TOKEN="null"
 
@@ -606,7 +624,11 @@ cat >$CONFIG_FILE <<-EOM
     "uploadMethod": "${STORAGE}",
     "ipfsInfuraProjectId": "${INFURA_ID}",
     "ipfsInfuraSecret": "${INFURA_SECRET}",
-    "awsS3Bucket": "${AWS_BUCKET}",
+    "awsConfig": {
+        "bucket": "${AWS_BUCKET}",
+        "profile": "${AWS_PROFILE}",
+        "directory": "${AWS_DIRECTORY}"
+    },
     "nftStorageAuthToken": "${NFT_STORAGE_TOKEN}",
     "shdwStorageAccount": $SHDW,
     "retainAuthority": true,
@@ -640,6 +662,8 @@ ARWEAVE_JWK="$ARWEAVE_JWK"
 INFURA_ID="$INFURA_ID"
 INFURA_SECRET="$INFURA_SECRET"
 AWS_BUCKET="$AWS_BUCKET"
+AWS_PROFILE="$AWS_PROFILE"
+AWS_DIRECTORY="$AWS_DIRECTORY"
 NFT_STORAGE_TOKEN="$NFT_STORAGE_TOKEN"
 SHDW_STORAGE_ACCOUNT="$SHDW_STORAGE_ACCOUNT"
 

--- a/src/hash/process.rs
+++ b/src/hash/process.rs
@@ -74,9 +74,9 @@ pub fn process_hash(args: HashArgs) -> Result<()> {
 
 pub fn hash_and_update(
     mut hidden_settings: HiddenSettings,
-    config_file: &String,
+    config_file: &str,
     config_data: &mut ConfigData,
-    cache_file_path: &String,
+    cache_file_path: &str,
 ) -> Result<String> {
     let mut hasher = Sha256::new();
 

--- a/src/sign/process.rs
+++ b/src/sign/process.rs
@@ -163,7 +163,7 @@ pub async fn process_sign(args: SignArgs) -> Result<()> {
 
         if !errors.is_empty() {
             pb.abandon_with_message(format!("{}", style("Signing command failed ").red().bold()));
-            return Err(anyhow!(format!("Not all NFTs were signed.")));
+            return Err(anyhow!("Not all NFTs were signed.".to_string()));
         } else {
             pb.finish_with_message(format!(
                 "{}",

--- a/src/validate/parser.rs
+++ b/src/validate/parser.rs
@@ -37,7 +37,7 @@ pub fn check_seller_fee_basis_points(
     Ok(())
 }
 
-pub fn check_creators_shares(creators: &Vec<Creator>) -> Result<(), ValidateParserError> {
+pub fn check_creators_shares(creators: &[Creator]) -> Result<(), ValidateParserError> {
     let mut shares = 0;
     for creator in creators {
         shares += creator.share;
@@ -49,7 +49,7 @@ pub fn check_creators_shares(creators: &Vec<Creator>) -> Result<(), ValidatePars
     Ok(())
 }
 
-pub fn check_creators_addresses(creators: &Vec<Creator>) -> Result<(), ValidateParserError> {
+pub fn check_creators_addresses(creators: &[Creator]) -> Result<(), ValidateParserError> {
     for creator in creators {
         Pubkey::from_str(&creator.address)
             .map_err(|_| ValidateParserError::InvalidCreatorAddress(creator.address.clone()))?;


### PR DESCRIPTION
### Context
* Update the Sugar CLI test to allow for testing the AWS upload option. Based on [the docs](https://docs.metaplex.com/developer-tools/sugar/upload-methods#amazon-aws-s3), we need a more complex config object - no longer just the bucket:

```
{
  . . .
  "uploadMethod": "aws",
  . . .
  "awsConfig": 
  {
    "bucket": "<BUCKET_NAME>",
    "profile": "<PROFILE_NAME>",
    "directory": "<DIRECTORY_NAME>",
  }
  . . .
}
```
* Other misc updates are due to clippy errors - I couldn't commit unless I fixed them 

### Testing
I tested locally both with env vars set and in interactive mode. If someone sets `STORAGE=aws` but forgets an AWS specific var, this logic will still prompt them for the missing var.