### PR TITLE
refactor(set/remove): formatting output

### DIFF
--- a/src/collections/remove.rs
+++ b/src/collections/remove.rs
@@ -104,17 +104,17 @@ pub fn process_remove_collection(args: RemoveCollectionArgs) -> Result<()> {
 
         // If hidden settings are enabled, we update the hash value in the config file and update the candy machine on-chain.
         if candy_machine_state.data.hidden_settings.is_some() {
-            println!(
-                "\nCandy machine has hidden settings and cache file was updated. Updating hash value..."
-            );
-
             let mut config_data = get_config_data(&args.config)?;
-
             let hidden_settings = config_data.hidden_settings.as_ref().unwrap().clone();
 
             println!(
-                "\nHidden settings hash: {}",
+                "\n{} {}",
+                style("Hidden settings hash:").bold(),
                 hash_and_update(hidden_settings, &args.config, &mut config_data, &args.cache,)?
+            );
+
+            println!(
+                "\nCandy machine has hidden settings and cache file was updated. Updating hash value...\n"
             );
 
             let update_args = UpdateArgs {

--- a/src/collections/set.rs
+++ b/src/collections/set.rs
@@ -123,17 +123,17 @@ pub fn process_set_collection(args: SetCollectionArgs) -> Result<()> {
 
         // If hidden settings are enabled, we update the hash value in the config file and update the candy machine on-chain.
         if candy_machine_state.data.hidden_settings.is_some() {
-            println!(
-                "\nCandy machine has hidden settings and cache file was updated. Updating hash value..."
-            );
-
             let mut config_data = get_config_data(&args.config)?;
-
             let hidden_settings = config_data.hidden_settings.as_ref().unwrap().clone();
 
             println!(
-                "\nHidden settings hash: {}",
+                "\n{} {}",
+                style("Hidden settings hash:").bold(),
                 hash_and_update(hidden_settings, &args.config, &mut config_data, &args.cache,)?
+            );
+
+            println!(
+                "\nCandy machine has hidden settings and cache file was updated. Updating hash value...\n"
             );
 
             let update_args = UpdateArgs {


### PR DESCRIPTION
Small tweak to the output of the `set` and `remove` collection commands.

- Current output:
![image](https://user-images.githubusercontent.com/729235/186285016-55268d2a-5043-4eee-ba17-31e6eb23c1c6.png)

- Updated output:
![image](https://user-images.githubusercontent.com/729235/186285054-6525e852-7bd9-4462-9717-7e9da004b76a.png)
