### PR TITLE
Support Sized Collections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2301,9 +2301,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-candy-machine"
-version = "4.1.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2feb2837b75c59a4476820ca2b96e157727a023b73a48315c3b9595907ab8306"
+checksum = "3cb48fe37fe9268a56f78452ec5191b1d55f0671398ae04a4cea78e8f00b1ef6"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ indexmap = { version = "1.9.1", features = ["serde"] }
 indicatif = { version = "0.16.2", features = ["rayon"] }
 ini = "1.3.0"
 lazy_static = "1.4.0"
-mpl-candy-machine = { version = "4.1.0", features = ["no-entrypoint"] }
+mpl-candy-machine = { version = "4.3.0", features = ["no-entrypoint"] }
 mpl-token-metadata = "1.3.4"
 num_cpus = "1.13.1"
 phf = { version = "0.10", features = ["macros"] }

--- a/src/deploy/collection.rs
+++ b/src/deploy/collection.rs
@@ -1,9 +1,9 @@
 use anchor_client::{solana_sdk::pubkey::Pubkey, Client};
 use anyhow::Result;
 use mpl_token_metadata::{
-    instruction::{create_master_edition_v3, create_metadata_accounts_v2},
+    instruction::{create_master_edition_v3, create_metadata_accounts_v3},
     pda::find_collection_authority_account,
-    state::Creator,
+    state::{CollectionDetails, Creator},
 };
 use spl_associated_token_account::{create_associated_token_account, get_associated_token_address};
 use spl_token::{
@@ -81,7 +81,7 @@ pub fn create_and_set_collection(
     };
     let collection_metadata_pubkey = find_metadata_pda(&collection_mint.pubkey());
 
-    let create_metadata_account_ix = create_metadata_accounts_v2(
+    let create_metadata_account_ix = create_metadata_accounts_v3(
         mpl_token_metadata::ID,
         collection_metadata_pubkey,
         collection_mint.pubkey(),
@@ -97,6 +97,7 @@ pub fn create_and_set_collection(
         true,
         None,
         None,
+        Some(CollectionDetails::V1 { size: 0 }),
     );
 
     let collection_edition_pubkey = find_master_edition_pda(&collection_mint.pubkey());


### PR DESCRIPTION
Creates sized collections by default when a collection asset pair is included in the assets directory. There's no real disadvantage I see to everyone having sized collections by default, but if someone really doesn't want a sized collection they can still create the collection parent NFT themselves as unsized and then use the `set-collection` command with Sugar to use it.

Waiting on this feature to be merged and deployed to candy machine devnet to test and finish this PR.