### PR TITLE
fix default devnet rpc url

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -77,7 +77,7 @@ pub const BUNDLR_DEVNET: &str = "https://devnet.bundlr.network";
 pub const BUNDLR_MAINNET: &str = "https://node1.bundlr.network";
 
 /// Default RPC endpoint for devnet.
-pub const DEFAULT_RPC_DEVNET: &str = "https://dev.genesysgo.net";
+pub const DEFAULT_RPC_DEVNET: &str = "https://devnet.genesysgo.net";
 
 pub const CIVIC_NETWORK: &str = "ignREusXmGrscGNUesoU9mxfds9AiYTezUKex2PsZV6";
 


### PR DESCRIPTION
https://dev.genesysgo.net is not a valid address and therefore causing issues like this:
![grafik](https://user-images.githubusercontent.com/93528482/187425200-00a0e849-ae7b-4012-a9f1-3d8827ccdf09.png)
`Error running command (re-run needed): error sending request for url (URL): error trying to connect: dns error: failed to lookup address information: nodename nor servname provided, or not known`

The correct url is https://devnet.genesysgo.net which I used now.