### PR TITLE
Fix division by zero error when verifying empty collection

### DIFF
--- a/src/verify/process.rs
+++ b/src/verify/process.rs
@@ -94,7 +94,11 @@ pub fn process_verify(args: VerifyArgs) -> Result<()> {
         println!("Verifying {} config line(s): (Ctrl+C to abort)", num_items);
         let pb = progress_bar_with_style(num_items as u64);
         // sleeps for a about 1 second
-        let step: u64 = 1_000_000 / num_items as u64;
+        let step: u64 = if num_items > 0 {
+            1_000_000 / num_items as u64
+        } else {
+            0
+        };
 
         for i in 0..num_items {
             let name_start = CONFIG_ARRAY_START


### PR DESCRIPTION
If `num_items` is 0 then we set `step` to `0` instead of `1_000_000 / num_items`

With this PR `sugar verify` works correctly for an empty collection:

```
>>> sugar verify

[1/2] 🍬 Loading candy machine
▪▪▪▪▪ Completed

[2/2] 📝 Verification
Verifying 0 config line(s): (Ctrl+C to abort)
[00:00:00] Config line verification successful █████████████████████████████████████████████████████ 0/0

Verification successful. You're good to go!

See your candy machine at:
  -> https://www.solaneyes.com/address/DqfEXKYn8Nct9xaY8A5xj2DUNkwZw8cJKXWS1Wwqt4oK?cluster=devnet

✅ Command successful.
```

Fixes #342 