### PR TITLE
Feat/add localnet cluster

### DIFF
--- a/src/bundlr/process.rs
+++ b/src/bundlr/process.rs
@@ -47,7 +47,7 @@ pub async fn process_bundlr(args: BundlrArgs) -> Result<()> {
     let bundlr_node = match solana_cluster {
         Cluster::Devnet => BUNDLR_DEVNET,
         Cluster::Mainnet => BUNDLR_MAINNET,
-        Cluster::Unknown => {
+        Cluster::Unknown | Cluster::Localnet => {
             return Err(anyhow!("Bundlr is only supported on devnet or mainnet"));
         }
     };

--- a/src/config/data.rs
+++ b/src/config/data.rs
@@ -366,6 +366,7 @@ impl Creator {
 pub enum Cluster {
     Devnet,
     Mainnet,
+    Localnet,
     Unknown,
 }
 
@@ -376,6 +377,7 @@ impl FromStr for Cluster {
         match s {
             "devnet" => Ok(Cluster::Devnet),
             "mainnet" => Ok(Cluster::Mainnet),
+            "localnet" => Ok(Cluster::Localnet),
             "unknown" => Ok(Cluster::Unknown),
             _ => Err(ConfigError::InvalidCluster(s.to_string()).into()),
         }
@@ -387,6 +389,7 @@ impl ToString for Cluster {
         match self {
             Cluster::Devnet => "devnet".to_string(),
             Cluster::Mainnet => "mainnet".to_string(),
+            Cluster::Localnet => "localnet".to_string(),
             Cluster::Unknown => "unknown".to_string(),
         }
     }

--- a/src/reveal/process.rs
+++ b/src/reveal/process.rs
@@ -107,13 +107,13 @@ pub async fn process_reveal(args: RevealArgs) -> Result<()> {
     };
 
     let metadata_pubkeys = match solana_cluster {
-        Cluster::Devnet => {
+        Cluster::Devnet | Cluster::Localnet => {
             let client = RpcClient::new(&rpc_url);
             let (creator, _) = find_candy_machine_creator_pda(&candy_machine_id);
             let creator = bs58::encode(creator).into_string();
             get_cm_creator_accounts(&client, &creator, 0)?
         }
-        Cluster::Mainnet | Cluster::Localnet => {
+        Cluster::Mainnet => {
             let client = RpcClient::new(&rpc_url);
             let crawled_accounts = Crawler::get_cmv2_mints(client, candy_machine_id).await?;
             match crawled_accounts.get("metadata") {

--- a/src/reveal/process.rs
+++ b/src/reveal/process.rs
@@ -100,6 +100,12 @@ pub async fn process_reveal(args: RevealArgs) -> Result<()> {
     let solana_cluster: Cluster = get_cluster(program.rpc())?;
     let rpc_url = get_rpc_url(args.rpc_url);
 
+    let solana_cluster = if rpc_url.ends_with("8899") {
+        Cluster::Localnet
+    } else {
+        solana_cluster
+    };
+
     let metadata_pubkeys = match solana_cluster {
         Cluster::Devnet => {
             let client = RpcClient::new(&rpc_url);
@@ -107,7 +113,7 @@ pub async fn process_reveal(args: RevealArgs) -> Result<()> {
             let creator = bs58::encode(creator).into_string();
             get_cm_creator_accounts(&client, &creator, 0)?
         }
-        Cluster::Mainnet => {
+        Cluster::Mainnet | Cluster::Localnet => {
             let client = RpcClient::new(&rpc_url);
             let crawled_accounts = Crawler::get_cmv2_mints(client, candy_machine_id).await?;
             match crawled_accounts.get("metadata") {

--- a/src/sign/process.rs
+++ b/src/sign/process.rs
@@ -104,6 +104,12 @@ pub async fn process_sign(args: SignArgs) -> Result<()> {
         let solana_cluster: Cluster = get_cluster(program.rpc())?;
         let rpc_url = get_rpc_url(args.rpc_url);
 
+        let solana_cluster = if rpc_url.ends_with("8899") {
+            Cluster::Localnet
+        } else {
+            solana_cluster
+        };
+
         let account_keys = match solana_cluster {
             Cluster::Devnet => {
                 let client = RpcClient::new(&rpc_url);
@@ -111,7 +117,7 @@ pub async fn process_sign(args: SignArgs) -> Result<()> {
                 let creator = bs58::encode(creator).into_string();
                 get_cm_creator_accounts(&client, &creator, 0)?
             }
-            Cluster::Mainnet => {
+            Cluster::Mainnet | Cluster::Localnet => {
                 let client = RpcClient::new(&rpc_url);
                 let crawled_accounts = Crawler::get_cmv2_mints(client, candy_machine_id).await?;
                 match crawled_accounts.get("metadata") {

--- a/src/sign/process.rs
+++ b/src/sign/process.rs
@@ -111,13 +111,13 @@ pub async fn process_sign(args: SignArgs) -> Result<()> {
         };
 
         let account_keys = match solana_cluster {
-            Cluster::Devnet => {
+            Cluster::Devnet | Cluster::Localnet => {
                 let client = RpcClient::new(&rpc_url);
                 let (creator, _) = find_candy_machine_creator_pda(&candy_machine_id);
                 let creator = bs58::encode(creator).into_string();
                 get_cm_creator_accounts(&client, &creator, 0)?
             }
-            Cluster::Mainnet | Cluster::Localnet => {
+            Cluster::Mainnet => {
                 let client = RpcClient::new(&rpc_url);
                 let crawled_accounts = Crawler::get_cmv2_mints(client, candy_machine_id).await?;
                 match crawled_accounts.get("metadata") {

--- a/src/upload/methods/bundlr.rs
+++ b/src/upload/methods/bundlr.rs
@@ -50,7 +50,7 @@ impl BundlrMethod {
         let bundlr_node = match solana_cluster {
             Cluster::Devnet => BUNDLR_DEVNET,
             Cluster::Mainnet => BUNDLR_MAINNET,
-            Cluster::Unknown => {
+            Cluster::Unknown | Cluster::Localnet => {
                 return Err(anyhow!("Bundlr is only supported on devnet or mainnet"));
             }
         };

--- a/src/upload/methods/shdw.rs
+++ b/src/upload/methods/shdw.rs
@@ -66,7 +66,7 @@ impl SHDWMethod {
             let endpoint = match solana_cluster {
                 Cluster::Devnet => DEVNET_ENDPOINT,
                 Cluster::Mainnet => MAINNET_ENDPOINT,
-                Cluster::Unknown => {
+                Cluster::Unknown | Cluster::Localnet => {
                     return Err(anyhow!(
                         "ShadowDrive is only supported on devnet or mainnet"
                     ));

--- a/src/verify/process.rs
+++ b/src/verify/process.rs
@@ -214,6 +214,7 @@ pub fn process_verify(args: VerifyArgs) -> Result<()> {
     let cluster = match get_cluster(program.rpc())? {
         Cluster::Devnet => "devnet",
         Cluster::Mainnet => "mainnet",
+        Cluster::Localnet => "",
         Cluster::Unknown => "",
     };
 


### PR DESCRIPTION
Adds a `Localnet` option to the `Cluster` enum to allow testing commands on localnet.