### PR TITLE
Fix `properties.category` being silently ignored

### DIFF
--- a/script/sugar-cli-test.sh
+++ b/script/sugar-cli-test.sh
@@ -485,7 +485,7 @@ read -r -d $'\0' METADATA <<-EOM
             "uri": "%s",
             "type": "%s"
         }%b
-        "category": "Sugar Test"
+        "category": "%s"
     }
 }
 EOM
@@ -504,7 +504,7 @@ read -r -d $'\0' COLLECTION <<-EOM
             "uri": "collection.png",
             "type": "image/png"
         }],
-        "category": "Sugar Test Collection"
+        "category": "image"
     }
 }
 EOM
@@ -548,13 +548,15 @@ if [ $RESUME -eq 0 ]; then
             MEDIA_TYPE="image/$EXT"
             ANIMATION_URL=","
             ANIMATION_FILE="],"
+            CATEGORY="image"
             cp "$ASSETS_DIR/template_image.$EXT" "$ASSETS_DIR/$i.$EXT"
             if [ "$ANIMATION" = 1 ]; then
                 cp "$ASSETS_DIR/template_animation.mp4" "$ASSETS_DIR/$i.mp4"
                 ANIMATION_URL=",\n\t\"animation_url\": \"$i.mp4\","
                 ANIMATION_FILE=",\n\t\t{\n\t\t\t\"uri\": \"$i.mp4\",\n\t\t\t\"type\": \"video/mp4\"\n\t\t}],"
+                CATEGORY="video"
             fi
-            printf "$METADATA" "$NAME" "$NAME" "$MEDIA_NAME" "$ANIMATION_URL" "$MEDIA_NAME" "$MEDIA_TYPE" "$ANIMATION_FILE" > "$ASSETS_DIR/$i.json"
+            printf "$METADATA" "$NAME" "$NAME" "$MEDIA_NAME" "$ANIMATION_URL" "$MEDIA_NAME" "$MEDIA_TYPE" "$ANIMATION_FILE" "$CATEGORY" > "$ASSETS_DIR/$i.json"
         done
         rm "$ASSETS_DIR/template_image.$EXT"
         # quietly removes the animation template (it might not exist)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -52,6 +52,8 @@ pub const CONFIG_URI_OFFSET: usize = STRING_LEN_SIZE + CONFIG_NAME_OFFSET + MAX_
 
 pub const MINT_LAYOUT: u64 = 82;
 
+pub const VALID_CATEGORIES: [&str; 5] = ["image", "video", "audio", "vr", "html"];
+
 pub const DEFAULT_UUID: &str = "000000";
 
 /// Maximum number of concurrent tasks (this is important for tasks that handle files

--- a/src/validate/errors.rs
+++ b/src/validate/errors.rs
@@ -41,4 +41,7 @@ pub enum ValidateParserError {
 
     #[error("Missing seller fee basis points field")]
     MissingSellerFeeBasisPoints,
+
+    #[error("Invalid category '{0}': must be one of: {1}")]
+    InvalidCategory(String, String),
 }

--- a/src/validate/parser.rs
+++ b/src/validate/parser.rs
@@ -3,7 +3,10 @@ use std::str::FromStr;
 use anchor_lang::prelude::Pubkey;
 pub use mpl_token_metadata::state::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH};
 
-use crate::validate::{errors::ValidateParserError, Creator};
+use crate::{
+    common::*,
+    validate::{errors::ValidateParserError, Creator},
+};
 
 pub fn check_name(name: &str) -> Result<(), ValidateParserError> {
     if name.len() > MAX_NAME_LENGTH {
@@ -53,6 +56,17 @@ pub fn check_creators_addresses(creators: &[Creator]) -> Result<(), ValidatePars
     for creator in creators {
         Pubkey::from_str(&creator.address)
             .map_err(|_| ValidateParserError::InvalidCreatorAddress(creator.address.clone()))?;
+    }
+
+    Ok(())
+}
+
+pub fn check_category(category: &str) -> Result<(), ValidateParserError> {
+    if !VALID_CATEGORIES.contains(&category) {
+        return Err(ValidateParserError::InvalidCategory(
+            category.to_string(),
+            format!("{:?}", VALID_CATEGORIES),
+        ));
     }
 
     Ok(())

--- a/src/validate/process.rs
+++ b/src/validate/process.rs
@@ -100,7 +100,7 @@ pub fn process_validate(args: ValidateArgs) -> Result<()> {
             }
         };
 
-        let metadata = match serde_json::from_reader::<File, Metadata>(f) {
+        let mut metadata = match serde_json::from_reader::<File, Metadata>(f) {
             Ok(metadata) => metadata,
             Err(error) => {
                 error!("{}: {}", path.display(), error);


### PR DESCRIPTION
If the `properties.category` field is not set for video, 3d and html nfts, they will not display properly on most wallets and marketplaces.
It [was part of the spec](https://docs.metaplex.com/programs/token-metadata/changelog/v1.0#:~:text=view%20the%20asset.-,properties.category,-%2D%20Supported%20categories%3A), but [seems to have dissapeared](https://docs.metaplex.com/programs/token-metadata/token-standard#:~:text=%5D%2C%0A%20%20%20%20%22-,category,-%22%3A%20%22video).