### PR TITLE
fix: correctly get decimals from mint account

### DIFF
--- a/src/deploy/initialize.rs
+++ b/src/deploy/initialize.rs
@@ -12,13 +12,14 @@ use mpl_candy_machine::{
 pub use mpl_token_metadata::state::{
     MAX_CREATOR_LIMIT, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH,
 };
-use solana_program::{native_token::LAMPORTS_PER_SOL, program_pack::Pack};
+use solana_program::native_token::LAMPORTS_PER_SOL;
 
 use crate::{
     candy_machine::{parse_config_price, CANDY_MACHINE_ID},
     common::*,
     config::data::*,
     deploy::errors::*,
+    utils::get_mint_decimals,
 };
 
 /// Create the candy machine data struct.
@@ -37,13 +38,7 @@ pub fn create_candy_machine_data(
     };
 
     // If SPL token is used, get the decimals from the token account, otherwise use 9 for SOL.
-    let decimals = if let Some(token_account) = &config.spl_token {
-        let token_account = program.rpc().get_account(token_account)?;
-        let token_account = spl_token::state::Mint::unpack(&token_account.data)?;
-        token_account.decimals
-    } else {
-        9
-    };
+    let decimals = get_mint_decimals(&program, config)?;
 
     let whitelist_mint_settings = config
         .whitelist_mint_settings

--- a/src/deploy/initialize.rs
+++ b/src/deploy/initialize.rs
@@ -37,7 +37,7 @@ pub fn create_candy_machine_data(
         None
     };
 
-    // If SPL token is used, get the decimals from the token account, otherwise use 9 for SOL.
+    // If SPL token is used, get the decimals from the token mint account, otherwise use 9 for SOL.
     let decimals = get_mint_decimals(&program, config)?;
 
     let whitelist_mint_settings = config

--- a/src/update/process.rs
+++ b/src/update/process.rs
@@ -198,7 +198,7 @@ fn create_candy_machine_data(
         None
     };
 
-    // If SPL token is used, get the decimals from the token account, otherwise use 9 for SOL.
+    // If SPL token is used, get the decimals from the token mint account, otherwise use 9 for SOL.
     let decimals = get_mint_decimals(&program, config)?;
 
     let whitelist_mint_settings = config

--- a/src/update/process.rs
+++ b/src/update/process.rs
@@ -7,7 +7,6 @@ use console::style;
 use mpl_candy_machine::{
     accounts as nft_accounts, instruction as nft_instruction, CandyMachineData,
 };
-use solana_program::program_pack::Pack;
 use spl_associated_token_account::get_associated_token_address;
 
 use crate::{
@@ -19,7 +18,8 @@ use crate::{
         parser::get_config_data,
     },
     utils::{
-        assert_correct_authority, check_spl_token, check_spl_token_account, spinner_with_style,
+        assert_correct_authority, check_spl_token, check_spl_token_account, get_mint_decimals,
+        spinner_with_style,
     },
 };
 
@@ -199,13 +199,7 @@ fn create_candy_machine_data(
     };
 
     // If SPL token is used, get the decimals from the token account, otherwise use 9 for SOL.
-    let decimals = if let Some(token_account) = &config.spl_token_account {
-        let token_account = program.rpc().get_account(token_account)?;
-        let token_account = spl_token::state::Mint::unpack(&token_account.data)?;
-        token_account.decimals
-    } else {
-        9
-    };
+    let decimals = get_mint_decimals(&program, config)?;
 
     let whitelist_mint_settings = config
         .whitelist_mint_settings

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,7 +23,10 @@ use solana_client::{
 };
 use spl_token::state::{Account as SplAccount, Mint};
 
-use crate::{common::*, config::data::Cluster};
+use crate::{
+    common::*,
+    config::{data::Cluster, ConfigData},
+};
 
 /// Hash for devnet cluster
 pub const DEVNET_HASH: &str = "EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG";
@@ -227,4 +230,15 @@ fn get_cm_creator_accounts(
     let results = client.get_program_accounts_with_config(&TOKEN_METADATA_PROGRAM_ID, config)?;
 
     Ok(results)
+}
+
+pub fn get_mint_decimals(program: &Program, config: &ConfigData) -> Result<u8> {
+    // If SPL token is used, get the decimals from the token account, otherwise use 9 for SOL.
+    if let Some(mint_pubkey) = config.spl_token {
+        let mint_account = program.rpc().get_account(&mint_pubkey)?;
+        let mint = spl_token::state::Mint::unpack(&mint_account.data)?;
+        Ok(mint.decimals)
+    } else {
+        Ok(9)
+    }
 }


### PR DESCRIPTION
The `update` command was incorrectly trying to parse decimals from the token account instead of the mint account. This code was duplicated in two places and the bug was only fixed in one. This PR abstracts this code into a helper function to reduce code duplication, and also fixes the bug. 