### PR TITLE
Fix typo during the validate cmd

### DIFF
--- a/src/validate/format.rs
+++ b/src/validate/format.rs
@@ -46,7 +46,7 @@ impl Metadata {
             self.properties.category = Some(category.to_string());
 
             println!(
-                "{} missing `properties.creator` for nft {}, defaulting to {}",
+                "{} missing `properties.category` for nft {}, defaulting to {}",
                 WARNING_EMOJI, &self.name, category
             );
         }


### PR DESCRIPTION
Fixing a typo while running the validate command. The metadata contained the creator address yet it was throwing warning for creator address so, digged a little bit to find out that it was related to category.