### PR TITLE
fix: update unfreeze-funds handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,8 +2302,6 @@ dependencies = [
 [[package]]
 name = "mpl-candy-machine"
 version = "4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cef262c477503a98bfcf6c0abd5e24fb1906a46c422289fb27541a4db2279a7"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -2317,9 +2315,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-token-metadata"
-version = "1.3.4"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029a329d7a89f7a3caf0b91bec307531f4b6c9cca34aa775454845fbbd05ac57"
+checksum = "3af5d66f2608f309ae54488f5e5154c98a1a860a15018426620b8ace580ed685"
 dependencies = [
  "arrayref",
  "borsh",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2301,7 +2301,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-candy-machine"
-version = "4.3.2"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75bae819b86d756a5c81107b708d626a9bdf24e32c4b0b52c2b2a00a5584095f"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,7 @@ indexmap = { version = "1.9.1", features = ["serde"] }
 indicatif = { version = "0.16.2", features = ["rayon"] }
 ini = "1.3.0"
 lazy_static = "1.4.0"
-mpl-candy-machine = { path = "../metaplex-program-library/candy-machine/program", features = ["no-entrypoint"] }
-# mpl-candy-machine = { version = "4.4", features = ["no-entrypoint"] }
+mpl-candy-machine = { version = "4.4", features = ["no-entrypoint"] }
 mpl-token-metadata = "~1.3.6"
 num_cpus = "1.13.1"
 phf = { version = "0.10", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ indexmap = { version = "1.9.1", features = ["serde"] }
 indicatif = { version = "0.16.2", features = ["rayon"] }
 ini = "1.3.0"
 lazy_static = "1.4.0"
-mpl-candy-machine = { version = "4.4", features = ["no-entrypoint"] }
+mpl-candy-machine = { path = "../metaplex-program-library/candy-machine/program", features = ["no-entrypoint"] }
+# mpl-candy-machine = { version = "4.4", features = ["no-entrypoint"] }
 mpl-token-metadata = "~1.3.6"
 num_cpus = "1.13.1"
 phf = { version = "0.10", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ indexmap = { version = "1.9.1", features = ["serde"] }
 indicatif = { version = "0.16.2", features = ["rayon"] }
 ini = "1.3.0"
 lazy_static = "1.4.0"
-mpl-candy-machine = { version = "4.3.2", features = ["no-entrypoint"] }
-mpl-token-metadata = "1.3.4"
+mpl-candy-machine = { version = "4.4", features = ["no-entrypoint"] }
+mpl-token-metadata = "~1.3.6"
 num_cpus = "1.13.1"
 phf = { version = "0.10", features = ["macros"] }
 rand = "0.8.5"

--- a/src/freeze/unfreeze_funds.rs
+++ b/src/freeze/unfreeze_funds.rs
@@ -61,7 +61,7 @@ pub fn process_unfreeze_funds(args: UnlockFundsArgs) -> Result<()> {
     let pb = spinner_with_style();
     pb.set_message("Sending unlock funds transaction...");
 
-    let signature = unlock_funds(&program, &candy_pubkey)?;
+    let signature = unlock_funds(&program, &candy_pubkey, candy_machine_state.wallet)?;
 
     pb.finish_with_message(format!(
         "{} {}",
@@ -72,7 +72,11 @@ pub fn process_unfreeze_funds(args: UnlockFundsArgs) -> Result<()> {
     Ok(())
 }
 
-pub fn unlock_funds(program: &Program, candy_machine_id: &Pubkey) -> Result<Signature> {
+pub fn unlock_funds(
+    program: &Program,
+    candy_machine_id: &Pubkey,
+    treasury: Pubkey,
+) -> Result<Signature> {
     let (freeze_pda, _) = find_freeze_pda(candy_machine_id);
 
     let builder = program
@@ -80,6 +84,7 @@ pub fn unlock_funds(program: &Program, candy_machine_id: &Pubkey) -> Result<Sign
         .accounts(nft_accounts::UnlockFunds {
             candy_machine: *candy_machine_id,
             authority: program.payer(),
+            wallet: treasury,
             freeze_pda,
             system_program: system_program::ID,
         })


### PR DESCRIPTION
DRAFT: requires `mpl-candy-machine` 4.4 released before merge and needs Cargo.toml file updated to not point to local package.