### PR TITLE
Handle transaction timeout during deploy

### DIFF
--- a/src/deploy/process.rs
+++ b/src/deploy/process.rs
@@ -108,13 +108,58 @@ pub async fn process_deploy(args: DeployArgs) -> Result<()> {
     let total_steps = 2 + (collection_in_cache as u8) + (config_data.freeze_time.is_some() as u8)
         - (hidden as u8);
 
-    let candy_pubkey = if candy_machine_address.is_empty() {
+    let mut candy_pubkey = Pubkey::default();
+    if !candy_machine_address.is_empty() {
+        println!(
+            "{} {}Loading candy machine",
+            style(format!("[1/{}]", total_steps)).bold().dim(),
+            CANDY_EMOJI
+        );
+
+        candy_pubkey = match Pubkey::from_str(candy_machine_address) {
+            Ok(pubkey) => pubkey,
+            Err(_err) => {
+                error!(
+                    "Invalid candy machine address in cache file: {}!",
+                    candy_machine_address
+                );
+                return Err(CacheError::InvalidCandyMachineAddress(
+                    candy_machine_address.to_string(),
+                )
+                .into());
+            }
+        };
+
+        match get_candy_machine_state(&Arc::clone(&sugar_config), &candy_pubkey) {
+            Ok(candy_state) => {
+                if candy_state.items_redeemed > 0 {
+                    item_redeemed = true;
+                }
+                if is_feature_active(&candy_state.data.uuid, FREEZE_FEATURE_INDEX) {
+                    freeze_deployed = true;
+                }
+            }
+            Err(_) => {
+                println!(
+                    "{} Candy machine {} not found on-chain",
+                    WARNING_EMOJI, candy_machine_address
+                );
+                println!(
+                    "{} This can happen if the deploy transaction fails or times out",
+                    WARNING_EMOJI
+                );
+
+                candy_pubkey = Pubkey::default();
+            }
+        }
+    }
+
+    if candy_pubkey == Pubkey::default() {
         println!(
             "{} {}Creating candy machine",
             style(format!("[1/{}]", total_steps)).bold().dim(),
             CANDY_EMOJI
         );
-        info!("Candy machine address is empty, creating new candy machine...");
 
         let spinner = spinner_with_style();
         spinner.set_message("Creating candy machine...");
@@ -149,6 +194,12 @@ pub async fn process_deploy(args: DeployArgs) -> Result<()> {
             },
         };
 
+        // save the candy machine pubkey to the cache _before_ attempting to deploy
+        // in case the transaction doesn't confirm in time the next run should pickup the pubkey
+        // and check if the deploy succeeded
+        cache.program = CacheProgram::new_from_cm(&candy_pubkey);
+        cache.sync_file()?;
+
         // all good, let's create the candy machine
 
         let sig = initialize_candy_machine(
@@ -164,49 +215,8 @@ pub async fn process_deploy(args: DeployArgs) -> Result<()> {
             &candy_pubkey.to_string()
         );
 
-        cache.program = CacheProgram::new_from_cm(&candy_pubkey);
-        cache.sync_file()?;
-
         spinner.finish_and_clear();
-
-        candy_pubkey
-    } else {
-        println!(
-            "{} {}Loading candy machine",
-            style(format!("[1/{}]", total_steps)).bold().dim(),
-            CANDY_EMOJI
-        );
-
-        let candy_pubkey = match Pubkey::from_str(candy_machine_address) {
-            Ok(pubkey) => pubkey,
-            Err(_err) => {
-                error!(
-                    "Invalid candy machine address in cache file: {}!",
-                    candy_machine_address
-                );
-                return Err(CacheError::InvalidCandyMachineAddress(
-                    candy_machine_address.to_string(),
-                )
-                .into());
-            }
-        };
-
-        match get_candy_machine_state(&Arc::clone(&sugar_config), &candy_pubkey) {
-            Ok(candy_state) => {
-                if candy_state.items_redeemed > 0 {
-                    item_redeemed = true;
-                }
-                if is_feature_active(&candy_state.data.uuid, FREEZE_FEATURE_INDEX) {
-                    freeze_deployed = true;
-                }
-            }
-            Err(_) => {
-                return Err(anyhow!("Candy machine from cache does't exist on chain!"));
-            }
-        }
-
-        candy_pubkey
-    };
+    }
 
     println!("{} {}", style("Candy machine ID:").bold(), candy_pubkey);
 

--- a/src/deploy/process.rs
+++ b/src/deploy/process.rs
@@ -165,7 +165,7 @@ pub async fn process_deploy(args: DeployArgs) -> Result<()> {
         spinner.set_message("Creating candy machine...");
 
         let candy_keypair = Keypair::new();
-        let candy_pubkey = candy_keypair.pubkey();
+        candy_pubkey = candy_keypair.pubkey();
 
         let uuid = DEFAULT_UUID.to_string();
         let candy_data = create_candy_machine_data(&client, &config_data, uuid)?;

--- a/src/deploy/process.rs
+++ b/src/deploy/process.rs
@@ -109,7 +109,13 @@ pub async fn process_deploy(args: DeployArgs) -> Result<()> {
         - (hidden as u8);
 
     let mut candy_pubkey = Pubkey::default();
-    if !candy_machine_address.is_empty() {
+    if candy_machine_address.is_empty() {
+        println!(
+            "{} {}Creating candy machine",
+            style(format!("[1/{}]", total_steps)).bold().dim(),
+            CANDY_EMOJI
+        );
+    } else {
         println!(
             "{} {}Loading candy machine",
             style(format!("[1/{}]", total_steps)).bold().dim(),
@@ -148,6 +154,7 @@ pub async fn process_deploy(args: DeployArgs) -> Result<()> {
                     "{} This can happen if the deploy transaction fails or times out",
                     WARNING_EMOJI
                 );
+                println!("{} Creating candy machine", CANDY_EMOJI);
 
                 candy_pubkey = Pubkey::default();
             }
@@ -155,12 +162,6 @@ pub async fn process_deploy(args: DeployArgs) -> Result<()> {
     }
 
     if candy_pubkey == Pubkey::default() {
-        println!(
-            "{} {}Creating candy machine",
-            style(format!("[1/{}]", total_steps)).bold().dim(),
-            CANDY_EMOJI
-        );
-
         let spinner = spinner_with_style();
         spinner.set_message("Creating candy machine...");
 


### PR DESCRIPTION
Saving the candy machine public key to the cache before sending the deploy transaction allows the cli to automatically detect if the deploy succeeded even if the transaction times out.

Behviour change:
Providing a valid public key that is not a candy machine in the cache results in a warning message and new candy machine being deployed.
The old behaviour was to print the message `Candy machine from cache does't exist on chain!`