### PR TITLE
fix(upload): allow use of existing animation url

### DIFF
--- a/src/upload/assets.rs
+++ b/src/upload/assets.rs
@@ -345,7 +345,11 @@ pub fn get_updated_metadata(
     }
 
     metadata.image = image_link.to_string();
-    metadata.animation_url = animation_link.clone();
+
+    if animation_link.is_some() {
+        // only updates the link if we have a new value
+        metadata.animation_url = animation_link.clone();
+    }
 
     Ok(serde_json::to_string(&metadata).unwrap())
 }


### PR DESCRIPTION
Currently Sugar will strip out the `animation_url` from a `json` metadata file if no animation file is found in the assets folder. This PR prevents this, so it is possible to specify an existing animation url directly on the `json` metadata.