### PR TITLE
Fix unintentional running of `cargo fmt`

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -7,7 +7,7 @@ set -eu
 if ! cargo +nightly fmt -- --check
 then
     echo "There are some code style issues."
-    echo "Run `cargo +nightly fmt` first."
+    echo "Run 'cargo +nightly fmt' first."
     exit 1
 fi
 


### PR DESCRIPTION
Backticks (`` ` ``) are a legacy form of the process substituion syntax (`$()`).
Printing the help message actually runs the command instead.
https://github.com/metaplex-foundation/sugar/blob/996c632535b0ae18057ce1c80edeedd67725ef7a/.cargo-husky/hooks/pre-commit#L10