### PR TITLE
Add option to specify a custom domain

### DIFF
--- a/script/sugar-cli-test.sh
+++ b/script/sugar-cli-test.sh
@@ -77,6 +77,9 @@ function default_settings() {
     INFURA_ID="null"
     INFURA_SECRET="null"
     AWS_BUCKET="null"
+    AWS_PROFILE="null"
+    AWS_DIRECTORY="null"
+    AWS_DOMAIN="null"
     NFT_STORAGE_TOKEN="null"
     SHDW_STORAGE_ACCOUNT="null"
 }
@@ -97,6 +100,9 @@ function max_settings() {
     INFURA_ID="null"
     INFURA_SECRET="null"
     AWS_BUCKET="null"
+    AWS_PROFILE="null"
+    AWS_DIRECTORY="null"
+    AWS_DOMAIN="null"
     NFT_STORAGE_TOKEN="null"
     SHDW_STORAGE_ACCOUNT="null"
 }
@@ -276,6 +282,19 @@ if [ -z ${AWS_DIRECTORY+x} ]; then
     if [ "$STORAGE" = "aws" ]; then
         echo -n $(CYN "AWS directory name: ")
         read AWS_DIRECTORY
+    fi
+fi
+
+if [ -z ${AWS_DOMAIN+x} ]; then
+    AWS_DOMAIN="https://$AWS_BUCKET.s3.amazonaws.com"
+
+    if [ "$STORAGE" = "aws" ]; then
+        echo -n "$(CYN "AWS custom domain") (default $AWS_DOMAIN): "
+        read Domain
+
+        if [ ! -z "$Domain" ]; then
+             AWS_DOMAIN=$Domain
+        fi
     fi
 fi
 
@@ -629,7 +648,8 @@ cat >$CONFIG_FILE <<-EOM
     "awsConfig": {
         "bucket": "${AWS_BUCKET}",
         "profile": "${AWS_PROFILE}",
-        "directory": "${AWS_DIRECTORY}"
+        "directory": "${AWS_DIRECTORY}",
+        "domain": "${AWS_DOMAIN}"
     },
     "nftStorageAuthToken": "${NFT_STORAGE_TOKEN}",
     "shdwStorageAccount": $SHDW,
@@ -666,6 +686,7 @@ INFURA_SECRET="$INFURA_SECRET"
 AWS_BUCKET="$AWS_BUCKET"
 AWS_PROFILE="$AWS_PROFILE"
 AWS_DIRECTORY="$AWS_DIRECTORY"
+AWS_DOMAIN="$AWS_DOMAIN"
 NFT_STORAGE_TOKEN="$NFT_STORAGE_TOKEN"
 SHDW_STORAGE_ACCOUNT="$SHDW_STORAGE_ACCOUNT"
 

--- a/src/config/data.rs
+++ b/src/config/data.rs
@@ -402,6 +402,7 @@ pub struct AwsConfig {
     pub bucket: String,
     pub profile: String,
     pub directory: String,
+    pub domain: Option<String>,
 }
 
 impl AwsConfig {
@@ -410,6 +411,7 @@ impl AwsConfig {
             bucket,
             profile,
             directory,
+            domain: None,
         }
     }
 }

--- a/src/config/data.rs
+++ b/src/config/data.rs
@@ -406,12 +406,17 @@ pub struct AwsConfig {
 }
 
 impl AwsConfig {
-    pub fn new(bucket: String, profile: String, directory: String) -> AwsConfig {
+    pub fn new(
+        bucket: String,
+        profile: String,
+        directory: String,
+        domain: Option<String>,
+    ) -> AwsConfig {
         AwsConfig {
             bucket,
             profile,
             directory,
-            domain: None,
+            domain,
         }
     }
 }

--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -634,7 +634,21 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
             .interact()
             .unwrap();
 
-        config_data.aws_config = Some(AwsConfig::new(bucket, profile, directory));
+        let domain: String = Input::with_theme(&theme)
+            .with_prompt("Do you have a custom domain? Leave blank to use AWS default domain.")
+            .interact()
+            .unwrap();
+
+        config_data.aws_config = Some(AwsConfig::new(
+            bucket,
+            profile,
+            directory,
+            if domain.is_empty() {
+                None
+            } else {
+                Some(domain)
+            },
+        ));
     }
 
     if config_data.upload_method == UploadMethod::NftStorage {

--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -630,12 +630,13 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
 
         let directory = Input::with_theme(&theme)
             .with_prompt("What is the directory to upload to? Leave blank to store files at the bucket root dir.")
-            .default(String::from(""))
+            .allow_empty(true)
             .interact()
             .unwrap();
 
         let domain: String = Input::with_theme(&theme)
             .with_prompt("Do you have a custom domain? Leave blank to use AWS default domain.")
+            .allow_empty(true)
             .interact()
             .unwrap();
 

--- a/src/upload/methods/aws.rs
+++ b/src/upload/methods/aws.rs
@@ -20,6 +20,7 @@ const MAX_RETRY: u8 = 3;
 pub struct AWSMethod {
     pub bucket: Arc<Bucket>,
     pub directory: String,
+    pub domain: String,
 }
 
 impl AWSMethod {
@@ -34,9 +35,16 @@ impl AWSMethod {
         let region = AWSMethod::load_region(config_data)?;
 
         if let Some(config) = &config_data.aws_config {
+            let domain = if let Some(domain) = &config.domain {
+                domain.to_string()
+            } else {
+                format!("https://{}.s3.amazonaws.com/", &config.bucket)
+            };
+
             Ok(Self {
                 bucket: Arc::new(Bucket::new(&config.bucket, region, credentials)?),
                 directory: config.directory.clone(),
+                domain,
             })
         } else {
             Err(anyhow!("Missing AwsConfig 'bucket' value in config file."))
@@ -71,6 +79,7 @@ impl AWSMethod {
     async fn send(
         bucket: Arc<Bucket>,
         directory: String,
+        domain: String,
         asset_info: AssetInfo,
     ) -> Result<(String, String)> {
         let data = match asset_info.data_type {
@@ -115,7 +124,7 @@ impl AWSMethod {
             }
         }
 
-        let link = format!("https://{}.s3.amazonaws.com/{}", bucket.name(), path_str);
+        let link = format!("{}/{}", domain, path_str);
 
         Ok((asset_info.asset_id, link))
     }
@@ -139,7 +148,8 @@ impl ParallelUploader for AWSMethod {
     fn upload_asset(&self, asset_info: AssetInfo) -> JoinHandle<Result<(String, String)>> {
         let bucket = self.bucket.clone();
         let directory = self.directory.clone();
+        let domain = self.domain.clone();
 
-        tokio::spawn(async move { AWSMethod::send(bucket, directory, asset_info).await })
+        tokio::spawn(async move { AWSMethod::send(bucket, directory, domain, asset_info).await })
     }
 }

--- a/src/upload/methods/aws.rs
+++ b/src/upload/methods/aws.rs
@@ -36,9 +36,14 @@ impl AWSMethod {
 
         if let Some(config) = &config_data.aws_config {
             let domain = if let Some(domain) = &config.domain {
-                domain.to_string()
+                match url::Url::parse(&domain.to_string()) {
+                    Ok(url) => url.to_string(),
+                    Err(error) => {
+                        return Err(anyhow!("Malformed domain URL ({})", error.to_string()))
+                    }
+                }
             } else {
-                format!("https://{}.s3.amazonaws.com/", &config.bucket)
+                format!("https://{}.s3.amazonaws.com", &config.bucket)
             };
 
             Ok(Self {
@@ -124,9 +129,9 @@ impl AWSMethod {
             }
         }
 
-        let link = format!("{}/{}", domain, path_str);
+        let link = url::Url::parse(&domain)?.join(path_str)?;
 
-        Ok((asset_info.asset_id, link))
+        Ok((asset_info.asset_id, link.to_string()))
     }
 }
 


### PR DESCRIPTION
Currently, the `aws` uploader creates URI using the standard AWS domain (`s3.amazonaws.com`). This PR adds an option to specify custom domains.

![image](https://user-images.githubusercontent.com/729235/194158177-285b39e0-acba-4846-aae8-75eb0b999763.png)
