### PR TITLE
print signature mint instead of sending it to ProgressBar

### DIFF
--- a/src/mint/process.rs
+++ b/src/mint/process.rs
@@ -124,7 +124,10 @@ pub async fn process_mint(args: MintArgs) -> Result<()> {
         )
         .await
         {
-            Ok(signature) => format!("{} {}", style("Signature:").bold(), signature),
+            Ok(signature) => {
+                println!("Signature: {}",signature);
+                format!("{}", style("Mint success").bold())
+            },
             Err(err) => {
                 pb.abandon_with_message(format!("{}", style("Mint failed ").red().bold()));
                 error!("{:?}", err);

--- a/src/mint/process.rs
+++ b/src/mint/process.rs
@@ -125,9 +125,9 @@ pub async fn process_mint(args: MintArgs) -> Result<()> {
         .await
         {
             Ok(signature) => {
-                println!("Signature: {}",signature);
+                println!("Signature: {}", signature);
                 format!("{}", style("Mint success").bold())
-            },
+            }
             Err(err) => {
                 pb.abandon_with_message(format!("{}", style("Mint failed ").red().bold()));
                 error!("{:?}", err);


### PR DESCRIPTION
This fixes the issue of being able to capture signature reading the terminal output programatically.

For example.. today.. if you run a mint and redirect the output with `> output.txt` you loose the signature id because ProgressBar will not print if is redirected or run outside a terminal. This behavior makes it impossible to automate tasks using sugar to mint NFTs and read the output.