### PR TITLE
Run CI workflow on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build and Release
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches: "**"
     tags:


### PR DESCRIPTION
#379 accidentally removed the `pull_request` trigger for the workflow.
This adds back the trigger to allow pull requests to be built and test.