### PR TITLE
ci: avoid redundant runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build and Release
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, reopened]
   push:
     branches: "**"
     tags:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Download [this installer binary](https://github.com/metaplex-foundation/winstall
 > ```
 
 
-
 ### Developers
 
 Using Crates.io:


### PR DESCRIPTION
Fixes the CI so it doesn't run actions twice on pushes to an open PR.

