### PR TITLE
fix: add missing accounts to unnlock-funds when token mint enabled

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -260,6 +260,10 @@ pub enum Commands {
         #[clap(long, default_value = DEFAULT_CACHE)]
         cache: String,
 
+        /// Path to the config file
+        #[clap(short, long, default_value = DEFAULT_CONFIG)]
+        config: String,
+
         /// Address of candy machine to update.
         candy_machine: Option<String>,
     },

--- a/src/freeze/unfreeze_funds.rs
+++ b/src/freeze/unfreeze_funds.rs
@@ -4,6 +4,7 @@ pub struct UnlockFundsArgs {
     pub keypair: Option<String>,
     pub rpc_url: Option<String>,
     pub cache: String,
+    pub config: String,
     pub candy_machine: Option<String>,
 }
 
@@ -11,6 +12,7 @@ pub fn process_unfreeze_funds(args: UnlockFundsArgs) -> Result<()> {
     let sugar_config = sugar_setup(args.keypair.clone(), args.rpc_url.clone())?;
     let client = setup_client(&sugar_config)?;
     let program = client.program(CANDY_MACHINE_ID);
+    let config_data = get_config_data(&args.config)?;
 
     // The candy machine id specified takes precedence over the one from the cache.
     let candy_machine_id = match args.candy_machine {
@@ -61,7 +63,12 @@ pub fn process_unfreeze_funds(args: UnlockFundsArgs) -> Result<()> {
     let pb = spinner_with_style();
     pb.set_message("Sending unlock funds transaction...");
 
-    let signature = unlock_funds(&program, &candy_pubkey, candy_machine_state.wallet)?;
+    let signature = unlock_funds(
+        &program,
+        &config_data,
+        &candy_pubkey,
+        candy_machine_state.wallet,
+    )?;
 
     pb.finish_with_message(format!(
         "{} {}",
@@ -74,10 +81,46 @@ pub fn process_unfreeze_funds(args: UnlockFundsArgs) -> Result<()> {
 
 pub fn unlock_funds(
     program: &Program,
+    config: &ConfigData,
     candy_machine_id: &Pubkey,
     treasury: Pubkey,
 ) -> Result<Signature> {
     let (freeze_pda, _) = find_freeze_pda(candy_machine_id);
+
+    let mut additional_accounts = Vec::new();
+
+    // If spl token mint setting is enabled, add the freeze ata to the accounts.
+    if let Some(spl_token_mint) = config.spl_token {
+        // Add Token program account.
+        additional_accounts.push(AccountMeta {
+            pubkey: spl_token::id(),
+            is_signer: false,
+            is_writable: false,
+        });
+
+        // Add the freeze ata.
+        let freeze_ata = get_associated_token_address(&freeze_pda, &spl_token_mint);
+
+        let freeze_ata_account = AccountMeta {
+            pubkey: freeze_ata,
+            is_signer: false,
+            is_writable: true,
+        };
+        additional_accounts.push(freeze_ata_account);
+
+        // Add the treasury ata.
+        let treasury_ata = if let Some(treasury_ata) = config.spl_token_account {
+            treasury_ata
+        } else {
+            get_associated_token_address(&treasury, &spl_token_mint)
+        };
+        let treasury = AccountMeta {
+            pubkey: treasury_ata,
+            is_signer: false,
+            is_writable: true,
+        };
+        additional_accounts.push(treasury);
+    }
 
     let builder = program
         .request()
@@ -88,6 +131,7 @@ pub fn unlock_funds(
             freeze_pda,
             system_program: system_program::ID,
         })
+        .accounts(additional_accounts) // order matters so we have to add this account at the end
         .args(nft_instruction::UnlockFunds);
 
     let sig = builder.send()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,11 +330,13 @@ async fn run() -> Result<()> {
             keypair,
             rpc_url,
             cache,
+            config,
             candy_machine,
         } => process_unfreeze_funds(UnlockFundsArgs {
             keypair,
             rpc_url,
             cache,
+            config,
             candy_machine,
         })?,
         Commands::Update {


### PR DESCRIPTION
The `unfreeze-funds` is missing some additional accounts required to work when SPL token mint is enabled.