### PR TITLE
Replace panic with proper error

### DIFF
--- a/src/upload/methods/aws.rs
+++ b/src/upload/methods/aws.rs
@@ -36,7 +36,7 @@ impl AWSMethod {
 
         if let Some(config) = &config_data.aws_config {
             let domain = if let Some(domain) = &config.domain {
-                match url::Url::parse(&domain.to_string()) {
+                match url::Url::parse(domain) {
                     Ok(url) => url.to_string(),
                     Err(error) => {
                         return Err(anyhow!("Malformed domain URL ({})", error.to_string()))

--- a/src/upload/process.rs
+++ b/src/upload/process.rs
@@ -349,7 +349,12 @@ pub async fn process_upload(args: UploadArgs) -> Result<()> {
     let mut count = 0;
 
     for (index, item) in &cache.items.0 {
-        let asset_pair = asset_pairs.get(&isize::from_str(index)?).unwrap();
+        let asset_pair = asset_pairs.get(&isize::from_str(index)?).ok_or_else(|| {
+            anyhow!(
+                "cache item {} does not have a corresponding asset pair",
+                index
+            )
+        })?;
 
         // we first check that the asset has an animation file; if there is one,
         // we need to check that the cache item has the link and the link is not empty


### PR DESCRIPTION
Someone triggered this error with a misconfigured cache file, so seems worth replacing the `unwrap` with a proper error. Also fixed a clippy lint.