### PR TITLE
add padding to bundlr fee calculation; fix clippy lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::uninlined_format_args)]
+
 pub mod airdrop;
 pub mod bundlr;
 pub mod cache;

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ fn setup_logging(level: Option<EnvFilter>) -> Result<()> {
     let file = OpenOptions::new()
         .write(true)
         .create(true)
-        .open(&log_path)
+        .open(log_path)
         .unwrap();
 
     // Prioritize user-provided level, otherwise read from RUST_LOG env var for log level, fall back to "tracing" if not set.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -13,7 +13,7 @@ pub fn parse_solana_config() -> Option<SolanaConfig> {
     } else if cfg!(windows) {
         let drive = env::var_os("HOMEDRIVE").expect("Couldn't find Windows home drive key.");
         let path = env::var_os("HOMEPATH").expect("Couldn't find Windows home path key.");
-        Path::new(&drive).join(&path).as_os_str().to_owned()
+        Path::new(&drive).join(path).as_os_str().to_owned()
     } else if cfg!(target_os = "macos") {
         env::var_os("HOME").expect("Couldn't find MacOS home key.")
     } else {

--- a/src/upload/methods/bundlr.rs
+++ b/src/upload/methods/bundlr.rs
@@ -290,6 +290,7 @@ impl Prepare for BundlrMethod {
             let program = client.program(CANDY_MACHINE_ID);
             program.rpc()
         };
+        let amount = ((lamports_fee - balance) as f64 * 1.3).ceil() as u64;
 
         if lamports_fee > balance {
             BundlrMethod::fund_bundlr_address(
@@ -298,7 +299,7 @@ impl Prepare for BundlrMethod {
                 &self.pubkey,
                 &self.node,
                 &sugar_config.keypair,
-                lamports_fee - balance,
+                amount,
             )
             .await?;
 


### PR DESCRIPTION
* Add padding to Bundlr fee calculation
* Fix clippy "needless borrow" lints
* Disable clippy "unlined_format_args" warnings