### PR TITLE
add ability to have different image file extensions in a single colleection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::uninlined_format_args)]
+// #![allow(clippy::uninlined_format_args)]
 
 pub mod airdrop;
 pub mod bundlr;

--- a/src/upload/methods/bundlr.rs
+++ b/src/upload/methods/bundlr.rs
@@ -290,9 +290,11 @@ impl Prepare for BundlrMethod {
             let program = client.program(CANDY_MACHINE_ID);
             program.rpc()
         };
-        let amount = ((lamports_fee - balance) as f64 * 1.3).ceil() as u64;
 
         if lamports_fee > balance {
+            // calculates the additional amount to fund the wallet, with padding.
+            let amount = ((lamports_fee - balance) as f64 * 1.3).ceil() as u64;
+
             BundlrMethod::fund_bundlr_address(
                 rpc_client,
                 &http_client,

--- a/src/upload/process.rs
+++ b/src/upload/process.rs
@@ -485,7 +485,7 @@ async fn upload_data(
     uploader: &dyn Uploader,
     interrupted: Arc<AtomicBool>,
 ) -> Result<Vec<UploadError>> {
-    let mut extension = HashSet::with_capacity(1);
+    let mut extension = String::new();
     let mut paths = Vec::new();
 
     for index in indices {
@@ -514,17 +514,11 @@ async fn upload_data(
             .extension()
             .and_then(OsStr::to_str)
             .expect("Failed to convert extension from unicode");
-        extension.insert(String::from(ext));
+
+        extension = String::from(ext);
 
         paths.push(file_path);
     }
-
-    // validates that all files have the same extension
-    let extension = if extension.len() == 1 {
-        extension.iter().next().unwrap()
-    } else {
-        return Err(anyhow!("Invalid file extension: {:?}", extension));
-    };
 
     let content_type = match data_type {
         DataType::Image => format!("image/{}", extension),


### PR DESCRIPTION
Add ability to have multiple different file extensions for images in a single collection.

Also moved amount calculation inside the condition in /methods/bundlr.rs to prevent panic, as well it should only need to be calculated when `lamports_fee > balance`. Was added inside the condition in #420 but then moved out in #421 


Also needed to remove (comment) `#![allow(clippy::uninlined_format_args)]` due to a clippy error. Added in #421.