### PR TITLE
Allow an existing collection on "sugar deploy"

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -73,6 +73,10 @@ pub enum Commands {
         /// Path to the cache file, defaults to "cache.json"
         #[clap(long, default_value = DEFAULT_CACHE)]
         cache: String,
+
+        /// The optional collection address where the candymachine will mint the tokens to
+        #[clap(long)]
+        collection_mint: Option<String>,
     },
 
     /// Manage freeze guard actions

--- a/src/launch/process.rs
+++ b/src/launch/process.rs
@@ -86,6 +86,7 @@ pub async fn process_launch(args: LaunchArgs) -> Result<()> {
         rpc_url: args.rpc_url.clone(),
         cache: args.cache.clone(),
         interrupted: args.interrupted.clone(),
+        collection_mint: None,
     };
 
     process_deploy(deploy_args).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,7 @@ async fn run() -> Result<()> {
             keypair,
             rpc_url,
             cache,
+            collection_mint,
         } => {
             process_deploy(DeployArgs {
                 config,
@@ -194,6 +195,7 @@ async fn run() -> Result<()> {
                 rpc_url,
                 cache,
                 interrupted: interrupted.clone(),
+                collection_mint,
             })
             .await?
         }


### PR DESCRIPTION
`sugar deploy` now accepts an optional argument (`--collection-mint <COLLECTION_MINT>`), which allows creating a candymachine without creating a collection.

Fixes #431

Tested with `sugar upload` then `sugar deploy` then `sugar mint`:
1. Define `0.json`/`0.jpg` with no `collection.json`, then, `sugar deploy --collection-mint <COLLECTION_MINT>`, [minted NFT](https://solscan.io/token/AGiG3cssSFkDP6Tn72d1enczvGY98SWdiDUSt6mihtrW?cluster=devnet) (new behavior).
2. Define `0.json`/`0.jpg` with no `collection.json`, create a candymachine with js code and set the output to `cache.json`, works as before.
3. Define `0.json`/`0.jpg` and `collection.json`/`collection.png`, works as before.
