### PR TITLE
Avoid Airdrop Double Sends

### DIFF
--- a/src/airdrop/process.rs
+++ b/src/airdrop/process.rs
@@ -127,6 +127,14 @@ pub async fn process_airdrop(args: AirdropArgs) -> Result<()> {
                         });
                     }
                     Err(err) => {
+                        // Assume timeouts succeed to avoid sending double to a recipient.
+                        if err.to_string().contains("Transaction was not confirmed in") {
+                            signatures.push(TransactionResult {
+                                signature: "RPC timeout: unknown if transaction succeeded"
+                                    .to_string(),
+                                status: true,
+                            });
+                        }
                         signatures.push(TransactionResult {
                             signature: err.to_string(),
                             status: false,

--- a/src/config/data.rs
+++ b/src/config/data.rs
@@ -187,9 +187,10 @@ impl HiddenSettings {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum UploadMethod {
+    #[default]
     Bundlr,
     #[serde(rename = "aws")]
     AWS,
@@ -202,12 +203,6 @@ pub enum UploadMethod {
 impl Display for UploadMethod {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
-    }
-}
-
-impl Default for UploadMethod {
-    fn default() -> UploadMethod {
-        UploadMethod::Bundlr
     }
 }
 

--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -231,7 +231,7 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
 
     let mut total_share = 0;
 
-    (0..num_creators).into_iter().for_each(|i| {
+    (0..num_creators).for_each(|i| {
         let address = Pubkey::from_str(
             &Input::with_theme(&theme)
                 .with_prompt(format!("Enter creator wallet address #{}", i + 1))

--- a/src/validate/process.rs
+++ b/src/validate/process.rs
@@ -76,11 +76,7 @@ pub fn process_validate(args: ValidateArgs) -> Result<()> {
 
     // Unwrapping here because we know the pattern is valid and GlobErrors should
     // be rare or impossible to produce.
-    let paths: Vec<PathBuf> = glob(pattern)
-        .unwrap()
-        .into_iter()
-        .map(Result::unwrap)
-        .collect();
+    let paths: Vec<PathBuf> = glob(pattern).unwrap().map(Result::unwrap).collect();
 
     // Validating continuous assets in directory
     validate_continuous_assets(&paths)?;


### PR DESCRIPTION
Addresses #432 in file `airdrop/process.rs`. Other files are clippy lint fixes.