### PR TITLE
Fix unminted indices offset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,6 +746,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
+name = "bytecount"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+
+[[package]]
 name = "bytemuck"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2792,6 +2798,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "papergrid"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae7891b22598926e4398790c8fe6447930c72a67d36d983a49d6ce682ce83290"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4716,6 +4733,7 @@ dependencies = [
  "solana-transaction-status",
  "spl-associated-token-account",
  "spl-token",
+ "tabled",
  "thiserror",
  "tokio",
  "tracing",
@@ -4767,6 +4785,30 @@ dependencies = [
  "quote 1.0.26",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
+]
+
+[[package]]
+name = "tabled"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "994ca3cfbe91dd1756a82a605a150fd7c9d9196cddc7af0612c1999cef224588"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99f688a08b54f4f02f0a3c382aefdb7884d3d69609f785bd253dc033243e3fe4"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ tracing = { version = "0.1.35", features = ["log"] }
 tracing-bunyan-formatter = "0.3.3"
 tracing-subscriber = { version = "0.3.14", features = ["registry", "env-filter"] }
 url = "2.2.2"
+tabled = "0.12.1"
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/script/sugar-cli-test.sh
+++ b/script/sugar-cli-test.sh
@@ -636,7 +636,7 @@ if [ $RESUME -eq 0 ]; then
     fi
 
     if [ "$MANUAL_CACHE" == "Y" ]; then
-        echo -n "{\"program\":{\"candyMachine\":\"\", \"candyMachineCreator\":\"\", \"collectionMint\":\"\"}, \"items\":{" >> $CACHE_FILE
+        echo -n "{\"program\":{\"candyMachine\":\"\", \"candyGuard\":\"\", \"candyMachineCreator\":\"\", \"collectionMint\":\"\"}, \"items\":{" >> $CACHE_FILE
 
         NAME="Collection"
         METADATA_HASH=`sha256sum "$ASSETS_DIR/collection.json" | cut -d ' ' -f 1`

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -6,42 +6,6 @@ pub use mpl_token_metadata::state::{
 /// Metaplex program id.
 pub const METAPLEX_PROGRAM_ID: &str = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s";
 
-/// Civic gateway program id.
-pub const CIVIC: &str = "gatem74V238djXdzWnJf94Wo1DcnuGkfijbf3AuBhfs";
-
-/// Start index of the config data in the PDA (offset calculated in bytes).
-pub const CONFIG_ARRAY_START: usize = 8 +   // key
-    32 +                                    // authority
-    32 +                                    // wallet
-    33 +                                    // token mint
-    4 + 6 +                                 // uuid
-    8 +                                     // price
-    8 +                                     // items available
-    9 +                                     // go live
-    10 +                                    // end settings
-    4 + MAX_SYMBOL_LENGTH +                 // u32 len + symbol
-    2 +                                     // seller fee basis points
-    4 + MAX_CREATOR_LIMIT*MAX_CREATOR_LEN + // optional + u32 len + actual vec
-    8 +                                     // max supply
-    1 +                                     // is mutable
-    1 +                                     // retain authority
-    1 +                                     // option for hidden setting
-    4 + MAX_NAME_LENGTH +                   // name length
-    4 + MAX_URI_LENGTH +                    // uri length
-    32 +                                    // hash
-    4 +                                     // max number of lines
-    8 +                                     // items redeemed
-    1 +                                     // whitelist option
-    1 +                                     // whitelist mint mode
-    1 +                                     // allow presale
-    9 +                                     // discount price
-    32 +                                    // mint key for whitelist
-    1 + 32 + 1                              // gatekeeper
-;
-
-/// Default length (in bytes) of a config line.
-pub const CONFIG_LINE_SIZE: usize = 4 + MAX_NAME_LENGTH + 4 + MAX_URI_LENGTH;
-
 pub const STRING_LEN_SIZE: usize = 4;
 
 pub const CONFIG_CHUNK_SIZE: usize = 10;


### PR DESCRIPTION
This PR fixes the display of unminted indices. The current code was using an incorrect offset. Additionally, the presentation of the indices was improves using the `tabled` crate.

<img width="638" alt="image" src="https://github.com/metaplex-foundation/sugar/assets/729235/f8603bbb-3512-4b6d-bd7a-2cc3a244eccd">
