### PR TITLE
add max-edition-supply config value

### DIFF
--- a/src/config/data.rs
+++ b/src/config/data.rs
@@ -77,6 +77,8 @@ pub struct ConfigData {
 
     /// Guards configuration
     pub guards: Option<CandyGuardData>,
+
+    pub max_edition_supply: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/deploy/initialize.rs
+++ b/src/deploy/initialize.rs
@@ -120,7 +120,7 @@ pub fn create_candy_machine_data(
         items_available: config.number,
         symbol: config.symbol.clone(),
         seller_fee_basis_points: config.seller_fee_basis_points,
-        max_supply: 0,
+        max_supply: config.max_edition_supply.unwrap_or(0),
         is_mutable: config.is_mutable,
         creators,
         config_line_settings,


### PR DESCRIPTION
Addresses #404. This value is present on Candy Machine's config, so should be exposed by Sugar as well.