### PR TITLE
Use index variable on name

### DIFF
--- a/script/sugar-cli-test.sh
+++ b/script/sugar-cli-test.sh
@@ -652,7 +652,7 @@ if [ $RESUME -eq 0 ]; then
             if [ "$HIDDEN" == "Y" ]; then
                 NAME="Reveal Item #$INDEX"
             else
-                NAME="[$TIMESTAMP] Test #$NAME"
+                NAME="[$TIMESTAMP] Test #$INDEX"
             fi
 
             METADATA_HASH=`sha256sum "$ASSETS_DIR/$i.json" | cut -d ' ' -f 1`


### PR DESCRIPTION
PR to fix the variable used to generate the name of the asset when the manual cache option is selected.