### PR TITLE
Adds SDrive as upload backend

### DIFF
--- a/src/config/data.rs
+++ b/src/config/data.rs
@@ -61,6 +61,9 @@ pub struct ConfigData {
     // AWS specific configuration
     pub aws_config: Option<AwsConfig>,
 
+    // SDRIVE specific configuration
+    pub sdrive_apikey: Option<String>,
+
     // NFT.Storage specific configuration
     #[serde(serialize_with = "to_option_string")]
     pub nft_storage_auth_token: Option<String>,
@@ -222,6 +225,8 @@ pub enum UploadMethod {
     #[serde(rename = "shdw")]
     SHDW,
     Pinata,
+    #[serde(rename = "sdrive")]
+    Sdrive,
 }
 
 impl Display for UploadMethod {

--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -309,7 +309,7 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
     };
 
     // upload method
-    let upload_options = vec!["Bundlr", "AWS", "NFT Storage", "SHDW", "Pinata"];
+    let upload_options = vec!["Bundlr", "AWS", "NFT Storage", "SHDW", "Pinata", "SDrive"];
     config_data.upload_method = match Select::with_theme(&theme)
         .with_prompt("What upload method do you want to use?")
         .items(&upload_options)
@@ -322,6 +322,7 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
         2 => UploadMethod::NftStorage,
         3 => UploadMethod::SHDW,
         4 => UploadMethod::Pinata,
+        5 => UploadMethod::Sdrive,
         _ => UploadMethod::Bundlr,
     };
 
@@ -365,6 +366,15 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
         config_data.nft_storage_auth_token = Some(
             Input::with_theme(&theme)
                 .with_prompt("What is the NFT Storage authentication token?")
+                .interact()
+                .unwrap(),
+        );
+    }
+
+    if config_data.upload_method == UploadMethod::Sdrive {
+        config_data.sdrive_apikey = Some(
+            Input::with_theme(&theme)
+                .with_prompt("What is your Sdrive API Key?")
                 .interact()
                 .unwrap(),
         );

--- a/src/upload/methods/mod.rs
+++ b/src/upload/methods/mod.rs
@@ -2,8 +2,10 @@ pub mod aws;
 pub mod bundlr;
 pub mod nft_storage;
 pub mod pinata;
+pub mod sdrive;
 pub mod shdw;
 
 pub use aws::*;
 pub use bundlr::*;
 pub use nft_storage::*;
+pub use sdrive::*;

--- a/src/upload/methods/sdrive.rs
+++ b/src/upload/methods/sdrive.rs
@@ -1,0 +1,110 @@
+use std::{fs, sync::Arc};
+
+use async_trait::async_trait;
+use reqwest::multipart::{Form, Part};
+use tokio::task::JoinHandle;
+
+use crate::{
+    common::*,
+    config::*,
+    upload::{
+        assets::{AssetPair, DataType},
+        uploader::{AssetInfo, ParallelUploader, Prepare},
+    },
+};
+
+// Maximum number of times to retry each individual upload.
+const MAX_RETRY: usize = 3;
+// Base URL for the SDrive API.
+const BASE_URL: &str = "https://sdrive.app/api/v3";
+
+#[derive(Deserialize)]
+struct UploadResponse {
+    status: String,
+    permalink: String,
+}
+
+pub struct SdriveMethod {
+    pub config: Arc<String>,
+}
+
+impl SdriveMethod {
+    pub async fn new(config_data: &ConfigData) -> Result<Self> {
+        if let Some(config) = &config_data.sdrive_apikey {
+            Ok(Self {
+                config: Arc::new(config.clone()),
+            })
+        } else {
+            Err(anyhow!("Missing SDrive values in config file."))
+        }
+    }
+
+    async fn send(apikey: String, asset_info: AssetInfo) -> Result<(String, String)> {
+        let data = match asset_info.data_type {
+            DataType::Image => fs::read(&asset_info.content)?,
+            DataType::Metadata => asset_info.content.into_bytes(),
+            DataType::Animation => fs::read(&asset_info.content)?,
+        };
+        let data_clone = data.clone(); // Clone the data outside the loop
+        let apikey_clone = apikey.clone(); // Clone the apikey outside the loop
+
+        let http_client = reqwest::Client::new();
+        let mut retries = 0;
+
+        loop {
+            let file = Part::bytes(data_clone.clone()) // Use the cloned data
+                .file_name(asset_info.name.clone())
+                .mime_str(asset_info.content_type.as_str())?;
+
+            let form = Form::new()
+                .part("fileupload", file)
+                .text("apikey", apikey_clone.clone()); // Use the cloned apikey
+
+            let response = http_client
+                .post(format!("{}/upload", &BASE_URL))
+                .multipart(form)
+                .send()
+                .await;
+
+            match response {
+                Ok(resp) => {
+                    if resp.status().is_success() {
+                        let upload_response: UploadResponse = resp.json().await?;
+                        if upload_response.status == "success" {
+                            return Ok((asset_info.asset_id.clone(), upload_response.permalink));
+                        }
+                    }
+                }
+                Err(_) => {} // Handle any error during sending
+            }
+
+            if retries >= MAX_RETRY {
+                break;
+            }
+            retries += 1;
+        }
+        Err(anyhow::anyhow!("Failed to upload to SDrive."))
+    }
+}
+
+#[async_trait]
+impl Prepare for SdriveMethod {
+    async fn prepare(
+        &self,
+        _sugar_config: &SugarConfig,
+        _asset_pairs: &HashMap<isize, AssetPair>,
+        _asset_indices: Vec<(DataType, &[isize])>,
+    ) -> Result<()> {
+        // nothing to do here
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ParallelUploader for SdriveMethod {
+    fn upload_asset(&self, asset_info: AssetInfo) -> JoinHandle<Result<(String, String)>> {
+        let apikey = self.config.clone();
+
+        tokio::spawn(async move { SdriveMethod::send(apikey.to_string(), asset_info).await })
+    }
+}

--- a/src/upload/methods/sdrive.rs
+++ b/src/upload/methods/sdrive.rs
@@ -10,6 +10,7 @@ use crate::{
     upload::{
         assets::{AssetPair, DataType},
         uploader::{AssetInfo, ParallelUploader, Prepare},
+        UploadError,
     },
 };
 
@@ -75,11 +76,11 @@ impl SdriveMethod {
                         }
                     }
                 }
-                Err(_) => {} // Handle any error during sending
-            }
-
-            if retries >= MAX_RETRY {
-                break;
+                Err(_) => {
+                    if retries >= MAX_RETRY {
+                        break;
+                    }
+                }
             }
             retries += 1;
         }

--- a/src/upload/methods/sdrive.rs
+++ b/src/upload/methods/sdrive.rs
@@ -10,7 +10,6 @@ use crate::{
     upload::{
         assets::{AssetPair, DataType},
         uploader::{AssetInfo, ParallelUploader, Prepare},
-        UploadError,
     },
 };
 

--- a/src/upload/uploader.rs
+++ b/src/upload/uploader.rs
@@ -289,5 +289,8 @@ pub async fn initialize(
         UploadMethod::Pinata => {
             Box::new(pinata::PinataMethod::new(config_data).await?) as Box<dyn Uploader>
         }
+        UploadMethod::Sdrive => {
+            Box::new(sdrive::SdriveMethod::new(config_data).await?) as Box<dyn Uploader>
+        }
     })
 }


### PR DESCRIPTION
Add SDrive as a new backend for upload. Sdrive is a service on top of Shadow Drive that makes effortless to upload images and metadata by providing an API endpoint rather than making the user go to hoops to create a storage account and have SHDW in their wallet.

It requires the user to have an API key from https://sdrive.app and API credits, and this PR makes sure the user is asked for their private key when they set up their mint.

The files are stored on immutable Shadow Drive storage accounts.

I did a test launch
https://www.solaneyes.com/address/ACeieWp9RkUoBZR4dAGTDWPkDJNT5RmMy3TH7VhfDNnE?cluster=devnet
and a test mint
https://solana.fm/address/ChHQTxBEFAhasJR5DgS7jpNaUpcwzi8McMHC2wDW7KG2?cluster=devnet-solana

using the test collection at Metaplex docs.

You need an API key to test with. I've loaded this key with some credits `fe312b8f7f25af5e22af64d1599c7261` (good for 100 uploads). Alternatively, register an account at sdrive.app and let me know and I'll provide API credits to the account. 

The benefit of this solution over centralized solutions such as AWS is that you only pay once (and not much) and don't have to keep a bucket alive forever, plus the metadata and images are stored permanently on Solana native, decentralized storage. 