### PR TITLE
fix: Update authority offset for cmv3: `8` -> `16`

### DIFF
--- a/src/withdraw/process.rs
+++ b/src/withdraw/process.rs
@@ -84,7 +84,7 @@ pub fn process_withdraw(args: WithdrawArgs) -> Result<()> {
         None => {
             let config = RpcProgramAccountsConfig {
                 filters: Some(vec![RpcFilterType::Memcmp(Memcmp::new_base58_encoded(
-                    8, // key
+                    16, // key
                     payer.as_ref(),
                 ))]),
                 account_config: RpcAccountInfoConfig {


### PR DESCRIPTION
`sugar withdraw` didn't fetch any candy machines for the keypair since the authority offset changed from `8` to `16` in candy machine v3.