### PR TITLE
feature: Add `--authority` option to `withdraw` subcommand

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -315,6 +315,12 @@ pub enum Commands {
         /// List available candy machines, no withdraw performed
         #[clap(long)]
         list: bool,
+
+        /// Address of authority to find candy machines for.
+        /// If authority != keypair.pubkey then force --list.
+        /// Defaults to keypair.pubkey.
+        #[clap(long)]
+        authority: Option<String>,
     },
 }
 

--- a/src/create_config/process.rs
+++ b/src/create_config/process.rs
@@ -220,7 +220,7 @@ pub fn process_create_config(args: CreateConfigArgs) -> Result<()> {
         .validate_with(number_validator)
         .validate_with({
             |input: &String| match input.parse::<u8>().unwrap() {
-                1 | 2 | 3 | 4 => Ok(()),
+                1..=4 => Ok(()),
                 _ => Err("Number of creator wallets must be between 1 and 4, inclusive."),
             }
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -503,11 +503,13 @@ async fn run() -> Result<()> {
             keypair,
             rpc_url,
             list,
+            authority,
         } => process_withdraw(WithdrawArgs {
             candy_machine,
             keypair,
             rpc_url,
             list,
+            authority,
         })?,
         Commands::Sign {
             keypair,

--- a/src/upload/assets.rs
+++ b/src/upload/assets.rs
@@ -362,5 +362,5 @@ pub fn get_updated_metadata(
 }
 
 pub fn is_complete_uri(value: &str) -> bool {
-    matches!(url::Url::parse(value), Ok(_))
+    url::Url::parse(value).is_ok()
 }

--- a/src/withdraw/process.rs
+++ b/src/withdraw/process.rs
@@ -84,7 +84,7 @@ pub fn process_withdraw(args: WithdrawArgs) -> Result<()> {
         None => {
             let config = RpcProgramAccountsConfig {
                 filters: Some(vec![RpcFilterType::Memcmp(Memcmp::new_base58_encoded(
-                    8, // key
+                    16, // key
                     payer.as_ref(),
                 ))]),
                 account_config: RpcAccountInfoConfig {

--- a/src/withdraw/process.rs
+++ b/src/withdraw/process.rs
@@ -33,6 +33,7 @@ pub struct WithdrawArgs {
     pub keypair: Option<String>,
     pub rpc_url: Option<String>,
     pub list: bool,
+    pub authority: Option<String>,
 }
 
 #[derive(Debug)]
@@ -53,20 +54,24 @@ pub fn process_withdraw(args: WithdrawArgs) -> Result<()> {
     let pb = spinner_with_style();
     pb.set_message("Connecting...");
 
-    let (program, payer) = setup_withdraw(args.keypair, args.rpc_url)?;
+    let (program, payer, authority) = setup_withdraw(args.keypair, args.rpc_url, args.authority)?;
 
     pb.finish_with_message("Connected");
+
+    // if --authority is specified and it does not match the keypair,
+    // then we cannot withdraw
+    let list = args.list || (payer != authority);
 
     println!(
         "\n{} {}{} funds",
         style("[2/2]").bold().dim(),
         WITHDRAW_EMOJI,
-        if args.list { "Listing" } else { "Retrieving" }
+        if list { "Listing" } else { "Retrieving" }
     );
 
     // the --list flag takes precedence; even if a candy machine id is passed
     // as an argument, we will list the candy machines (no draining happens)
-    let candy_machine = if args.list { None } else { args.candy_machine };
+    let candy_machine = if list { None } else { args.candy_machine };
 
     // (2) Retrieving data for listing/draining
 
@@ -85,7 +90,7 @@ pub fn process_withdraw(args: WithdrawArgs) -> Result<()> {
             let config = RpcProgramAccountsConfig {
                 filters: Some(vec![RpcFilterType::Memcmp(Memcmp::new_base58_encoded(
                     16, // key
-                    payer.as_ref(),
+                    authority.as_ref(),
                 ))]),
                 account_config: RpcAccountInfoConfig {
                     encoding: Some(UiAccountEncoding::Base64),
@@ -122,7 +127,7 @@ pub fn process_withdraw(args: WithdrawArgs) -> Result<()> {
             );
 
             if !accounts.is_empty() {
-                if args.list {
+                if list {
                     println!("\n{:48} Balance", "Candy Machine ID");
                     println!("{:-<61}", "-");
 
@@ -207,13 +212,19 @@ pub fn process_withdraw(args: WithdrawArgs) -> Result<()> {
 fn setup_withdraw(
     keypair: Option<String>,
     rpc_url: Option<String>,
-) -> Result<(Program<Rc<Keypair>>, Pubkey)> {
+    authority_opt: Option<String>,
+) -> Result<(Program<Rc<Keypair>>, Pubkey, Pubkey)> {
     let sugar_config = sugar_setup(keypair, rpc_url)?;
     let client = setup_client(&sugar_config)?;
     let program = client.program(CANDY_MACHINE_ID);
     let payer = program.payer();
+    let authority = if let Some(authority_str) = authority_opt {
+        Pubkey::from_str(&authority_str)?
+    } else {
+        payer
+    };
 
-    Ok((program, payer))
+    Ok((program, payer, authority))
 }
 
 fn do_withdraw<C: Deref<Target = impl Signer> + Clone>(


### PR DESCRIPTION
Allows listing other user's candy machines by passing `--authority`, useful for debugging.
Fixes the authority offset from 8 to 16 for Candy Machine v3 (replaces #464).
Also fixes clippy warnings.

```console
> sugar withdraw -h

sugar-withdraw
Withdraw funds a from candy machine account closing it

USAGE:
    sugar withdraw [OPTIONS]

OPTIONS:
        --authority <AUTHORITY>
            Address of authority to find candy machines for. If authority != keypair.pubkey then
            force --list. Defaults to keypair.pubkey
...
```