### PR TITLE
Fix Build, release 2.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4725,7 +4725,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "sugar-cli"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "anchor-client",
  "anchor-lang",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sugar-cli"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2021"
 description = "Command line tool for creating and managing Metaplex Candy Machines."
 license = "Apache-2.0"

--- a/src/show/process.rs
+++ b/src/show/process.rs
@@ -161,11 +161,11 @@ pub fn process_show(args: ShowArgs) -> Result<()> {
         } else {
             style(config_line_settings.prefix_name.as_str())
         };
-        print_with_style("    ", "prefix_name", &prefix_name.to_string());
+        print_with_style("    ", "prefix_name", prefix_name.to_string());
         print_with_style(
             "    ",
             "name_length",
-            &config_line_settings.name_length.to_string(),
+            config_line_settings.name_length.to_string(),
         );
 
         let prefix_uri = if config_line_settings.prefix_uri.is_empty() {
@@ -173,11 +173,11 @@ pub fn process_show(args: ShowArgs) -> Result<()> {
         } else {
             style(config_line_settings.prefix_uri.as_str())
         };
-        print_with_style("    ", "prefix_uri", &prefix_uri.to_string());
+        print_with_style("    ", "prefix_uri", prefix_uri.to_string());
         print_with_style(
             "    ",
             "uri_length",
-            &config_line_settings.uri_length.to_string(),
+            config_line_settings.uri_length.to_string(),
         );
         print_with_style(
             "    ",


### PR DESCRIPTION
After the last merge, which technically just changed some strings, the build was failing.
This fixes it and releases a new 2.6.1 version to have the new developer hub url in the binary.