### PR TITLE
Fix m1 pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    env:
+      MATRIX_OS: ${{ matrix.os }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -51,14 +54,10 @@ jobs:
             binary_extension=".exe"
             binary_path="sugar-windows-latest${binary_extension}"
           elif [[ "${RUNNER_OS}" == "macOS" ]]; then
-            arch=$(uname -m)
-            if [[ "${arch}" == "x86_64" ]]; then
-              binary_path="sugar-macos-intel-latest"
-            elif [[ "${arch}" == "arm64" ]]; then
+            if [[ "${MATRIX_OS}" == "macos-14" ]]; then
               binary_path="sugar-macos-m1-latest"
             else
-              echo "error: unknown macOS architecture: ${arch}"
-              exit 1
+              binary_path="sugar-macos-intel-latest"
             fi
           elif [[ "${RUNNER_OS}" == "Linux" ]]; then
             binary_path="sugar-ubuntu-latest"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,6 @@ jobs:
           if [[ "${RUNNER_OS}" == "Windows" ]]; then
             binary_extension=".exe"
             binary_path="sugar-windows-latest${binary_extension}"
-          elif [[ "${RUNNER_OS}" == "macOS-14" ]]; then
-            binary_path="sugar-macos-m1-latest"
           elif [[ "${RUNNER_OS}" == "macOS" ]]; then
             arch=$(uname -m)
             if [[ "${arch}" == "x86_64" ]]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,15 @@ jobs:
           elif [[ "${RUNNER_OS}" == "macOS-14" ]]; then
             binary_path="sugar-macos-m1-latest"
           elif [[ "${RUNNER_OS}" == "macOS" ]]; then
-            binary_path="sugar-macos-intel-latest"
+            arch=$(uname -m)
+            if [[ "${arch}" == "x86_64" ]]; then
+              binary_path="sugar-macos-intel-latest"
+            elif [[ "${arch}" == "arm64" ]]; then
+              binary_path="sugar-macos-m1-latest"
+            else
+              echo "error: unknown macOS architecture: ${arch}"
+              exit 1
+            fi
           elif [[ "${RUNNER_OS}" == "Linux" ]]; then
             binary_path="sugar-ubuntu-latest"
           else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
           - windows-latest
           - ubuntu-latest
           - macos-latest
+          - macos-14
 
     runs-on: ${{ matrix.os }}
 
@@ -49,6 +50,8 @@ jobs:
           if [[ "${RUNNER_OS}" == "Windows" ]]; then
             binary_extension=".exe"
             binary_path="sugar-windows-latest${binary_extension}"
+          elif [[ "${RUNNER_OS}" == "macOS-14" ]]; then
+            binary_path="sugar-macos-m1-latest"
           elif [[ "${RUNNER_OS}" == "macOS" ]]; then
             binary_path="sugar-macos-intel-latest"
           elif [[ "${RUNNER_OS}" == "Linux" ]]; then


### PR DESCRIPTION
Currently no binary for m1 is created. The macos 14 runner is based on m1. By adding it it should be created.