### PR TITLE
Replace solaneyes with explorer.solana.com

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4725,7 +4725,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "sugar-cli"
-version = "2.7.1"
+version = "2.7.2"
 dependencies = [
  "anchor-client",
  "anchor-lang",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sugar-cli"
-version = "2.7.1"
+version = "2.7.2"
 edition = "2021"
 description = "Command line tool for creating and managing Metaplex Candy Machines."
 license = "Apache-2.0"

--- a/src/verify/process.rs
+++ b/src/verify/process.rs
@@ -216,7 +216,7 @@ pub fn process_verify(args: VerifyArgs) -> Result<()> {
         println!("\nVerification successful. You're good to go!");
     } else {
         println!(
-            "\nVerification successful. You're good to go!\n\nSee your candy machine at:\n  -> https://www.solaneyes.com/address/{}?cluster={}",
+            "\nVerification successful. You're good to go!\n\nSee your candy machine at:\n  -> https://www.explorer.solana.com/address/{}?cluster={}",
             cache.program.candy_machine,
             cluster
         );


### PR DESCRIPTION
Solaneyes is not working correctly for a long time now and shows Candy Machines as not existing. This is causing confusion for users, therefore we should point them to a working explorer instead.