### PR TITLE
feature: Add flag `--new-update-authority` to the Reveal Command

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -214,6 +214,10 @@ pub enum Commands {
         /// RPC timeout to retrieve the mint list (in seconds).
         #[clap(short, long)]
         timeout: Option<u64>,
+
+        /// Address to transfer the update authority to
+        #[clap(short, long)]
+        new_update_authority: Option<String>,
     },
 
     /// Show the on-chain config of an existing candy machine

--- a/src/main.rs
+++ b/src/main.rs
@@ -468,6 +468,7 @@ async fn run() -> Result<()> {
             cache,
             config,
             timeout,
+            new_update_authority,
         } => {
             process_reveal(RevealArgs {
                 keypair,
@@ -475,6 +476,7 @@ async fn run() -> Result<()> {
                 cache,
                 config,
                 timeout,
+                new_update_authority,
             })
             .await?
         }


### PR DESCRIPTION
Implement `sugar reveal --new-update-authority <public key>` to allow transferring the update authority during the reveal process.