### PR TITLE
Switching to plain deserialize for TM resize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,10 +1227,11 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
+ "powerfmt",
  "serde",
 ]
 
@@ -2613,6 +2614,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2999,6 +3006,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -4929,12 +4942,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.28"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -4942,16 +4957,17 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/src/config/data.rs
+++ b/src/config/data.rs
@@ -278,14 +278,18 @@ impl FromStr for Cluster {
     }
 }
 
-impl ToString for Cluster {
-    fn to_string(&self) -> String {
-        match self {
-            Cluster::Devnet => "devnet".to_string(),
-            Cluster::Mainnet => "mainnet".to_string(),
-            Cluster::Localnet => "localnet".to_string(),
-            Cluster::Unknown => "unknown".to_string(),
-        }
+impl Display for Cluster {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Cluster::Devnet => "devnet",
+                Cluster::Mainnet => "mainnet",
+                Cluster::Localnet => "localnet",
+                Cluster::Unknown => "unknown",
+            }
+        )
     }
 }
 

--- a/src/deploy/process.rs
+++ b/src/deploy/process.rs
@@ -13,8 +13,9 @@ use anchor_client::solana_sdk::{
     signature::{Keypair, Signer},
 };
 use anyhow::Result;
+use borsh::BorshDeserialize;
 use console::style;
-use mpl_token_metadata::state::{Metadata, TokenMetadataAccount};
+use mpl_token_metadata::state::Metadata;
 
 use crate::{
     cache::*,
@@ -175,7 +176,7 @@ pub async fn process_deploy(args: DeployArgs) -> Result<()> {
 
         let collection_metadata = find_metadata_pda(&collection_mint);
         let data = program.rpc().get_account_data(&collection_metadata)?;
-        let metadata = Metadata::safe_deserialize(data.as_slice())?;
+        let metadata = Metadata::deserialize(&mut data.as_slice())?;
 
         let sig = initialize_candy_machine(
             &config_data,

--- a/src/freeze/thaw.rs
+++ b/src/freeze/thaw.rs
@@ -3,6 +3,7 @@
 use std::{fmt::Display, time::Duration};
 
 use anchor_client::solana_sdk::compute_budget::ComputeBudgetInstruction;
+use borsh::BorshDeserialize;
 use mpl_candy_guard::{
     accounts::Route as RouteAccount, guards::FreezeInstruction, instruction::Route,
     instructions::RouteArgs, state::GuardType,
@@ -251,7 +252,8 @@ pub async fn process_thaw(args: ThawArgs) -> Result<()> {
                         .unwrap()
                         .value
                         .unwrap();
-                    let metadata = Metadata::safe_deserialize(&metadata_account.data).unwrap();
+                    let metadata =
+                        Metadata::deserialize(&mut metadata_account.data.as_slice()).unwrap();
 
                     let rule_set = if let Some(ProgrammableConfig::V1 { rule_set }) =
                         metadata.programmable_config
@@ -460,7 +462,8 @@ pub async fn process_thaw(args: ThawArgs) -> Result<()> {
                             .unwrap()
                             .value
                             .unwrap();
-                        let metadata = Metadata::safe_deserialize(&metadata_account.data).unwrap();
+                        let metadata =
+                            Metadata::deserialize(&mut metadata_account.data.as_slice()).unwrap();
 
                         let rule_set = if let Some(ProgrammableConfig::V1 { rule_set }) =
                             metadata.programmable_config

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@ fn setup_logging(level: Option<EnvFilter>) -> Result<()> {
     let file = OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(true)
         .open(log_path)
         .unwrap();
 

--- a/src/mint/process.rs
+++ b/src/mint/process.rs
@@ -7,6 +7,7 @@ use anchor_client::solana_sdk::{
     system_program, sysvar,
 };
 use anyhow::Result;
+use borsh::BorshDeserialize;
 use console::style;
 use mpl_candy_machine_core::{
     accounts as nft_accounts, instruction as nft_instruction, AccountVersion, CandyMachine,
@@ -17,7 +18,7 @@ use mpl_token_metadata::{
         find_collection_authority_account, find_metadata_delegate_record_account,
         find_token_record_account,
     },
-    state::{Metadata, TokenMetadataAccount},
+    state::Metadata,
 };
 use solana_client::rpc_response::Response;
 use spl_associated_token_account::get_associated_token_address;
@@ -250,7 +251,7 @@ pub async fn mint(
     let collection_metadata = find_metadata_pda(&collection_mint);
 
     let data = program.rpc().get_account_data(&collection_metadata)?;
-    let metadata = Metadata::safe_deserialize(data.as_slice())?;
+    let metadata = Metadata::deserialize(&mut data.as_slice())?;
 
     let metadata_pda = find_metadata_pda(&nft_mint.pubkey());
     let master_edition_pda = find_master_edition_pda(&nft_mint.pubkey());

--- a/src/pdas.rs
+++ b/src/pdas.rs
@@ -5,9 +5,10 @@ use anchor_client::{
     Program,
 };
 use anyhow::{anyhow, Result};
+use borsh::BorshDeserialize;
 use mpl_token_metadata::{
     pda::{find_master_edition_account, find_metadata_account},
-    state::{Key, MasterEditionV2, Metadata, TokenMetadataAccount, MAX_MASTER_EDITION_LEN},
+    state::{Key, MasterEditionV2, Metadata, MAX_MASTER_EDITION_LEN},
     utils::try_from_slice_checked,
 };
 
@@ -37,7 +38,7 @@ pub fn get_metadata_pda<C: Deref<Target = impl Signer> + Clone>(
             &metadata_pubkey.to_string()
         )
     })?;
-    let metadata = Metadata::safe_deserialize(metadata_account.data.as_slice());
+    let metadata = Metadata::deserialize(&mut metadata_account.data.as_slice());
     metadata.map(|m| (metadata_pubkey, m)).map_err(|_| {
         anyhow!(
             "Failed to deserialize metadata account: {}",

--- a/src/upload/process.rs
+++ b/src/upload/process.rs
@@ -55,7 +55,7 @@ pub async fn process_upload(args: UploadArgs) -> Result<()> {
 
     // creates/loads the cache
     let mut cache = load_cache(&args.cache, true)?;
-    if asset_pairs.get(&-1).is_none() {
+    if !asset_pairs.contains_key(&-1) {
         cache.items.remove("-1");
     }
 


### PR DESCRIPTION
Replacing the overcautious safe_deserialize for TM Metadata accounts with the less safe deserialize. This should not be an issue because ownership and necessary checks are checked on-chain.

Additional changes are added to get the code to properly compile and should have no effect on functionality.